### PR TITLE
Fixed order of nom&prenom in JORFSearch queries

### DIFF
--- a/commands/follow.ts
+++ b/commands/follow.ts
@@ -24,7 +24,7 @@ module.exports = (bot: TelegramBot) => async (msg: TelegramBot.Message) => {
     await bot.sendChatAction(chatId, "typing");
     const question = await bot.sendMessage(
       chatId,
-      "Entrez le nom et prénom de la personne que vous souhaitez suivre:",
+      "Entrez le prénom et nom de la personne que vous souhaitez suivre:",
       {
         reply_markup: {
           force_reply: true,

--- a/commands/unfollow.js
+++ b/commands/unfollow.js
@@ -113,11 +113,10 @@ module.exports = (bot) => async (msg) => {
         if (peoples.length > 0) {
           text += "Voici les personnes que vous suivez :\n\n";
           for (j; j < peoples.length; j++) {
-            let nomPrenom = `${peoples[j].nom} ${peoples[j].prenom}`;
             text += `${
-              j + 1 + i
-            }. *${nomPrenom}* - [JORFSearch](https://jorfsearch.steinertriples.ch/name/${encodeURI(
-              nomPrenom
+                j + 1 + i
+            }. *${peoples[j].nom} ${peoples[j].prenom}* - [JORFSearch](https://jorfsearch.steinertriples.ch/name/${encodeURI(
+                `${peoples[j].prenom} ${peoples[j].nom}`
             )})\n\n`;
           }
         }


### PR DESCRIPTION
The recommended format for JORF queries is Prénom Nom.

As mentioned in the construction page (3.2), using a different order could lead to identification issues, especially with people having a 2-part lastname (particule).
https://www.steinertriples.ch/ncohen/data/nominations_JORF/apropos.php

![image](https://github.com/user-attachments/assets/083cdb1a-ff17-446d-8ae5-92be7d9524cd)

![image](https://github.com/user-attachments/assets/c468ace3-480e-4e7a-9d23-e6b164dc20a3)

![image](https://github.com/user-attachments/assets/b81d2976-d500-4e94-b299-c76a767f5365)
