### PR TITLE
Correction : records de promotion de militaires

### DIFF
--- a/utils/formatSearchResult.ts
+++ b/utils/formatSearchResult.ts
@@ -21,7 +21,7 @@ if (elem.armee_grade) {
     if (elem.type_ordre == "nomination") {
         message += `👉 au grade de *${elem.armee_grade}*`;
     } else if (elem.type_ordre == "promotion") {
-        message += ` (TA)`;
+        message += `👉 au grade de *${elem.armee_grade}* (TA)`;
     }
     if (elem.armee === "réserve") {
         message += ` de réserve`;


### PR DESCRIPTION
La PR permet de corriger un problème d'affichage lorsque le grade est correctement présent dans un record de promotion de militaire.

Example:
https://jorfsearch.steinertriples.ch/name/Ewan%20Belb%C3%A9och

| Avant PR      | Après PR      |
| ------------- | ------------- |
| ![Screenshot_20241208-122448](https://github.com/user-attachments/assets/2a0b7ac2-658a-47a8-ae1a-bb1ee875fb7e) | ![Screenshot_20241208-122431](https://github.com/user-attachments/assets/375d3a63-6817-4f4f-94b0-38165e24ecd4)
 

