### PR TITLE
Ajout des dates d'effet pour les décisions de nomination

### DIFF
--- a/utils/formatSearchResult.ts
+++ b/utils/formatSearchResult.ts
@@ -1,4 +1,5 @@
-import { textTypeOrdre, textPublishDate } from "./formatting.utils";
+import { textTypeOrdre } from "./formatting.utils";
+import { dateToFrenchString } from "./date.utils";
 
 function addPoste(
   elem: {
@@ -54,16 +55,19 @@ if (elem.armee_grade) {
 }
 
 function addLinkJO(
-  elem: { source_id: any; source_name: any },
+  elem: { source_id: any; source_name: any ; source_date: any },
   message: string
 ) {
-  if (elem.source_id) {
+
+  if (elem.source_id && !elem.source_date) {
+      message += `🔗 _JO du ${dateToFrenchString(elem.source_date)}_: `;
+
     switch (elem.source_name) {
       case "BOMI":
-        message += `🔗 _Lien JO_:  [cliquez ici](https://bodata.steinertriples.ch/${elem.source_id}.pdf)\n`;
+        message += `[cliquez ici](https://bodata.steinertriples.ch/${elem.source_id}.pdf)\n`;
         break;
       default:
-        message += `🔗 _Lien JO_:  [cliquez ici](https://www.legifrance.gouv.fr/jorf/id/${elem.source_id})\n`;
+        message += `[cliquez ici](https://www.legifrance.gouv.fr/jorf/id/${elem.source_id})\n`;
     }
   }
   return message;
@@ -95,7 +99,18 @@ export function formatSearchResult(
     }
     message += textTypeOrdre(elem.type_ordre || "nomination", elem.sexe || "M");
     message = addPoste(elem, message);
-    message += textPublishDate(elem.source_date);
+
+    if (elem?.date_debut) {
+      if (elem.type_ordre === "nomination" && (elem?.armee_grade || elem?.grade)) {
+          message += `🗓 Pour prendre rang du ${dateToFrenchString(elem.date_debut)}\n`;
+      } else {
+          if (elem?.date_fin)
+              message += `🗓 Du ${dateToFrenchString(elem.date_debut)} au ${dateToFrenchString(elem.date_fin)}\n`;
+          else {
+            message += `🗓 À compter du ${dateToFrenchString(elem.date_debut)}\n`;
+            }
+      }
+    }
     message = addLinkJO(elem, message);
     message += "\n";
   }

--- a/utils/formatting.utils.ts
+++ b/utils/formatting.utils.ts
@@ -1,5 +1,4 @@
 import { TypeOrdre } from "../types";
-import { dateToFrenchString } from "./date.utils";
 
 export const textTypeOrdre = (
   type_ordre: TypeOrdre,
@@ -43,11 +42,4 @@ export const textTypeOrdre = (
     default:
       return `📝 A été _${type_ordre}_ à:\n`;
   }
-};
-
-export const textPublishDate = (date: string): string => {
-  if (date) {
-    return `🗓 _Publié le_:  ${dateToFrenchString(date)} \n`;
-  }
-  return "";
 };


### PR DESCRIPTION
Les décisions d'avancement en grade des fonctionnaires et militaires sont très souvent décalées (quelques jours), ou carrément rétroactives (plusieurs mois, jusqu'à 1 an).
Ce diférence de calendrier n'est pas visible sur la présentation actuelle des décisions.

De plus, les décisions peuvent correspondre à des nominations temporaires (cursus, missions).

La PR permet de visualiser ces cas spécifiques:

Example:
https://jorfsearch.steinertriples.ch/name/Ewan%20Belb%C3%A9och

| Avant PR      | Après PR      |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/a3dbf79c-a4a7-4be9-aa76-949284f885e7) | ![image](https://github.com/user-attachments/assets/ff92a296-1f76-4532-b89f-a0b1e187ade8)
 

