### PR TITLE
feat(signal): poll-based menus + finish interface stubs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -34,5 +34,7 @@ MATRIX_BOT_ENCRYPTION=TRUE
 SIGNAL_PHONE_NUMBER=""
 SIGNAL_DEVICE_NAME=""
 SIGNAL_BAT_PATH='.\node_modules\signal-sdk\bin\signal-cli-0.13.18\bin\signal-cli.bat'
+# Render menus as native Signal polls (default: enabled). Set to "false" to use the plain-text menu.
+SIGNAL_USE_POLLS=""
 
 JAVA_TOOL_OPTIONS='-Dfile.encoding=UTF-8'

--- a/apps/signalApp.ts
+++ b/apps/signalApp.ts
@@ -2,7 +2,8 @@ import "dotenv/config";
 
 import { SignalCli } from "signal-sdk";
 import { mongodbConnect, mongodbDisconnect } from "../db.ts";
-import { SignalSession } from "../entities/SignalSession.ts";
+import { SignalSession, toSignalRecipient } from "../entities/SignalSession.ts";
+import { resolvePollVote } from "../entities/SignalPollRegistry.ts";
 import { startDailyNotificationJobs } from "../notifications/notificationScheduler.ts";
 import { logError } from "../utils/debugLogger.ts";
 import { handleIncomingMessage } from "../utils/messageWorkflow.ts";
@@ -18,11 +19,22 @@ if (SIGNAL_BAT_PATH === undefined) {
   throw new Error("SIGNAL_BAT_PATH env variable not set");
 }
 
+interface ISignalPollVote {
+  author?: string;
+  authorNumber?: string;
+  authorUuid?: string;
+  targetSentTimestamp: number;
+  optionIndexes: number[];
+  voteCount: number;
+}
+
 interface ISignalMessage {
   envelope: {
     sourceNumber: string;
+    timestamp?: number;
     dataMessage?: {
       message?: string;
+      pollVote?: ISignalPollVote;
     };
     receiptMessage?: never;
   };
@@ -67,31 +79,58 @@ await (async () => {
     // Start the bot by connecting to MongoDB
     await mongodbConnect();
 
-    // Connect to signal-cli daemon
-    await signalCli.connect();
+    // Connect to signal-cli daemon, sending read receipts for incoming messages
+    await signalCli.connect({ sendReadReceipts: true });
 
     // Listen for incoming messages
     signalCli.on("message", (message: ISignalMessage) => {
       void (async () => {
         try {
-          if (message.envelope.sourceNumber === SIGNAL_PHONE_NUMBER) return;
+          const { envelope } = message;
+          if (envelope.sourceNumber === SIGNAL_PHONE_NUMBER) return;
 
-          const msgText = message.envelope.dataMessage?.message;
+          const messageSentTime =
+            envelope.timestamp != null
+              ? new Date(envelope.timestamp)
+              : new Date();
+
+          const buildSession = (text: string) =>
+            handleIncomingMessage(
+              new SignalSession(
+                signalCli,
+                SIGNAL_PHONE_NUMBER,
+                envelope.sourceNumber,
+                "fr",
+                messageSentTime
+              ),
+              text,
+              { errorContext: "Error processing command" }
+            );
+
+          // A vote on a poll menu: map the selected option index back to its
+          // menu label, close the poll, then dispatch as a normal command.
+          const pollVote = envelope.dataMessage?.pollVote;
+          if (pollVote !== undefined) {
+            const optionText = resolvePollVote(
+              pollVote.targetSentTimestamp,
+              pollVote.optionIndexes
+            );
+            if (optionText === undefined) return;
+
+            await signalCli
+              .sendPollTerminate(toSignalRecipient(envelope.sourceNumber), {
+                pollTimestamp: pollVote.targetSentTimestamp
+              })
+              .catch(() => undefined);
+
+            await buildSession(optionText);
+            return;
+          }
+
+          const msgText = envelope.dataMessage?.message;
           if (msgText === undefined) return;
 
-          const messageSentTime = new Date(); // TODO: use the real message timestamp
-
-          const signalSession = new SignalSession(
-            signalCli,
-            SIGNAL_PHONE_NUMBER,
-            message.envelope.sourceNumber,
-            "fr",
-            messageSentTime
-          );
-
-          await handleIncomingMessage(signalSession, msgText, {
-            errorContext: "Error processing command"
-          });
+          await buildSession(msgText);
         } catch (error) {
           await logError("Signal", "Error processing command", error);
         }

--- a/commands/default.ts
+++ b/commands/default.ts
@@ -1,5 +1,4 @@
 import { ISession } from "../types.ts";
-import { Keyboard, KEYBOARD_KEYS } from "../entities/Keyboard.ts";
 import {
   ExternalMessageOptions,
   MiniUserInfo,
@@ -53,7 +52,6 @@ export async function sendMainMenu(
     let message = MAIN_MENU_MESSAGE;
     let separateMenuMessage = undefined;
 
-    let keyboard: Keyboard | undefined = undefined;
     switch (userInfo.messageApp) {
       case "Tchap":
       case "Matrix":
@@ -65,22 +63,18 @@ export async function sendMainMenu(
         break;
 
       case "Signal":
-        keyboard = [
-          [KEYBOARD_KEYS.FOLLOWS_LIST.key],
-          [KEYBOARD_KEYS.FUNCTION_FOLLOW.key],
-          [KEYBOARD_KEYS.HELP.key]
-        ];
+        // Poll buttons (analog to Matrix) are added on top of the body; the
+        // text-command menu stays as guidance and as the polls-off fallback.
+        separateMenuMessage = true;
         message += "\n\n" + TEXT_COMMANDS_MENU;
     }
     if (options.session != null)
       await options.session.sendMessage(message, {
-        keyboard,
         separateMenuMessage
       });
     else if (options.externalOptions != null)
       await sendMessage(userInfo, message, {
         ...options.externalOptions,
-        keyboard,
         separateMenuMessage,
         useAsyncUmamiLog: true,
         hasAccount: userInfo.hasAccount

--- a/entities/Keyboard.ts
+++ b/entities/Keyboard.ts
@@ -133,3 +133,15 @@ export const KEYBOARD_KEYS: Record<
     keepFollowUpAlive: true
   }
 };
+
+// Shared main-menu option list rendered as a poll on platforms that support it
+// (Matrix/Tchap and Signal). Keep ≤ 10 entries: Signal polls cap at 10 options.
+export const POLL_MENU_KEYS: KeyboardKey[] = [
+  KEYBOARD_KEYS.PEOPLE_SEARCH.key,
+  KEYBOARD_KEYS.ORGANISATION_FOLLOW.key,
+  KEYBOARD_KEYS.FUNCTION_FOLLOW.key,
+  KEYBOARD_KEYS.TEXT_SEARCH.key,
+  KEYBOARD_KEYS.ENA_INSP_PROMO_SEARCH_LONG_NO_KEYBOARD.key,
+  KEYBOARD_KEYS.FOLLOWS_LIST.key,
+  KEYBOARD_KEYS.HELP.key
+];

--- a/entities/MatrixSession.ts
+++ b/entities/MatrixSession.ts
@@ -13,7 +13,7 @@ import {
   splitText
 } from "../utils/text.utils.ts";
 import { MatrixClient, MatrixError } from "matrix-bot-sdk";
-import { Keyboard, KEYBOARD_KEYS, KeyboardKey } from "./Keyboard.ts";
+import { Keyboard, KEYBOARD_KEYS, POLL_MENU_KEYS } from "./Keyboard.ts";
 import { logError } from "../utils/debugLogger.ts";
 
 export const MATRIX_MESSAGE_CHAR_LIMIT = 5000;
@@ -26,16 +26,6 @@ export const MATRIX_API_SENDING_CONCURRENCY = 1;
 const MAX_MESSAGE_RETRY = 5;
 
 const mainMenuKeyboardMatrix: Keyboard = [[KEYBOARD_KEYS.MAIN_MENU.key]];
-
-const fullMenuKeyboard: KeyboardKey[] = [
-  KEYBOARD_KEYS.PEOPLE_SEARCH.key,
-  KEYBOARD_KEYS.ORGANISATION_FOLLOW.key,
-  KEYBOARD_KEYS.FUNCTION_FOLLOW.key,
-  KEYBOARD_KEYS.TEXT_SEARCH.key,
-  KEYBOARD_KEYS.ENA_INSP_PROMO_SEARCH_LONG_NO_KEYBOARD.key,
-  KEYBOARD_KEYS.FOLLOWS_LIST.key,
-  KEYBOARD_KEYS.HELP.key
-];
 
 interface ExtendedMatrixClient {
   matrix: MatrixClient;
@@ -257,7 +247,7 @@ export async function sendMatrixMessage(
         userInfo.roomId,
         {
           title: KEYBOARD_KEYS.MAIN_MENU.key.text,
-          options: fullMenuKeyboard.map((k) => ({ text: k.text }))
+          options: POLL_MENU_KEYS.map((k) => ({ text: k.text }))
         },
         options.hasAccount
       );

--- a/entities/SignalPollRegistry.ts
+++ b/entities/SignalPollRegistry.ts
@@ -1,0 +1,72 @@
+// In-memory registry mapping a sent Signal poll (keyed by its send timestamp)
+// to the ordered list of option labels it was built from.
+//
+// Signal poll votes arrive as numeric option indexes
+// (envelope.dataMessage.pollVote.optionIndexes), unlike Matrix poll responses
+// which carry the answer text directly. We therefore remember the options we
+// sent so an incoming vote can be resolved back to its menu label.
+//
+// The Signal bot is a single process, so a module-level Map is sufficient.
+// Menus are ephemeral: entries expire after a TTL and the map is size-capped.
+
+const POLL_REGISTRY_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+const POLL_REGISTRY_MAX_ENTRIES = 500;
+
+interface PollMenuEntry {
+  options: string[];
+  expiresAt: number;
+}
+
+const pollRegistry = new Map<number, PollMenuEntry>();
+
+function evictExpired(now: number): void {
+  for (const [timestamp, entry] of pollRegistry) {
+    if (entry.expiresAt <= now) pollRegistry.delete(timestamp);
+  }
+}
+
+/** Remember the ordered options of a poll menu we just sent. */
+export function registerPollMenu(
+  pollTimestamp: number,
+  options: string[]
+): void {
+  const now = Date.now();
+  evictExpired(now);
+
+  // Size cap: drop oldest insertion(s). Map preserves insertion order, so the
+  // first key iterated is the oldest.
+  while (pollRegistry.size >= POLL_REGISTRY_MAX_ENTRIES) {
+    for (const oldest of pollRegistry.keys()) {
+      pollRegistry.delete(oldest);
+      break;
+    }
+  }
+
+  pollRegistry.set(pollTimestamp, {
+    options: [...options],
+    expiresAt: now + POLL_REGISTRY_TTL_MS
+  });
+}
+
+/**
+ * Resolve an incoming poll vote to the selected option label.
+ * Returns undefined if the poll is unknown/expired or the index is out of range.
+ */
+export function resolvePollVote(
+  targetSentTimestamp: number,
+  optionIndexes: number[]
+): string | undefined {
+  evictExpired(Date.now());
+
+  const entry = pollRegistry.get(targetSentTimestamp);
+  if (entry === undefined) return undefined;
+
+  // optionIndexes[0] may be absent (empty vote) and the index may be out of
+  // range; both yield undefined here, which is the intended "no match" result.
+  return entry.options[optionIndexes[0]];
+}
+
+/** Test helper: clear all registered polls. */
+export function clearPollRegistry(): void {
+  pollRegistry.clear();
+}

--- a/entities/SignalSession.ts
+++ b/entities/SignalSession.ts
@@ -10,6 +10,8 @@ import umami, { UmamiEvent, UmamiLogger } from "../utils/umami.ts";
 import { markdown2plainText, splitText } from "../utils/text.utils.ts";
 import { SignalCli } from "signal-sdk";
 import { logError } from "../utils/debugLogger.ts";
+import { KEYBOARD_KEYS, POLL_MENU_KEYS } from "./Keyboard.ts";
+import { registerPollMenu } from "./SignalPollRegistry.ts";
 
 const SignalMessageApp: MessageApp = "Signal";
 
@@ -17,6 +19,15 @@ export const SIGNAL_MESSAGE_CHAR_LIMIT = 2000;
 const SIGNAL_COOL_DOWN_DELAY_SECONDS = 6;
 
 export const SIGNAL_API_SENDING_CONCURRENCY = 1;
+
+// Render menus as native Signal polls (analog to Matrix). Disable with
+// SIGNAL_USE_POLLS=false to keep the plain-text menu instead.
+const SIGNAL_USE_POLLS = process.env.SIGNAL_USE_POLLS !== "false";
+
+// Signal poll constraints (signal-cli): 2–10 options, each 1–100 characters.
+const SIGNAL_POLL_MAX_OPTIONS = 10;
+const SIGNAL_POLL_OPTION_MAX_CHARS = 100;
+const SIGNAL_POLL_MENU_TITLE = KEYBOARD_KEYS.MAIN_MENU.key.text;
 
 export class SignalSession implements ISession {
   messageApp = SignalMessageApp;
@@ -54,7 +65,10 @@ export class SignalSession implements ISession {
   }
 
   sendTypingAction() {
-    // TODO: check implementation in Signal
+    // Best-effort typing indicator; never block or throw on failure.
+    void this.signalCli
+      .sendTyping(toSignalRecipient(this.chatId))
+      .catch(() => undefined);
   }
 
   log(args: { event: UmamiEvent; payload?: Record<string, unknown> }) {
@@ -107,6 +121,11 @@ export async function extractSignalAppSession(
   return session;
 }
 
+/** Ensure a Signal recipient is in +E.164 form. */
+export function toSignalRecipient(phone: string): string {
+  return phone.startsWith("+") ? phone : "+" + phone;
+}
+
 export async function sendSignalAppMessage(
   signalCli: SignalCli,
   userPhoneId: string,
@@ -118,9 +137,7 @@ export async function sendSignalAppMessage(
     : umami.log;
   try {
     const cleanMessage = markdown2plainText(message);
-    const userPhoneIdInt = userPhoneId.startsWith("+")
-      ? userPhoneId
-      : "+" + userPhoneId;
+    const userPhoneIdInt = toSignalRecipient(userPhoneId);
     const mArr = splitText(cleanMessage, SIGNAL_MESSAGE_CHAR_LIMIT);
     for (const elem of mArr) {
       await signalCli.sendMessage(userPhoneIdInt, elem);
@@ -136,10 +153,106 @@ export async function sendSignalAppMessage(
         setTimeout(resolve, SIGNAL_COOL_DOWN_DELAY_SECONDS * 1000)
       );
     }
+
+    // Render the menu as a poll (analog to Matrix).
+    if (options.separateMenuMessage) {
+      // Main menu: the message body already carries a text-command menu, so a
+      // poll only adds tap-to-navigate buttons. If it fails, the body stands.
+      if (SIGNAL_USE_POLLS)
+        await sendSignalPollMenu(
+          signalCli,
+          userPhoneIdInt,
+          SIGNAL_POLL_MENU_TITLE,
+          POLL_MENU_KEYS.map((k) => k.text),
+          options.hasAccount
+        );
+    } else if (options.keyboard != null) {
+      // Sub-menu: render the keyboard as a poll, else a plain-text option list.
+      const optionTexts = options.keyboard.flat().map((k) => k.text);
+      if (optionTexts.length >= 2) {
+        const pollSent =
+          SIGNAL_USE_POLLS &&
+          (await sendSignalPollMenu(
+            signalCli,
+            userPhoneIdInt,
+            SIGNAL_POLL_MENU_TITLE,
+            optionTexts,
+            options.hasAccount
+          ));
+        if (!pollSent)
+          await sendSignalMenuFallbackText(
+            signalCli,
+            userPhoneIdInt,
+            optionTexts
+          );
+      }
+    }
+
     await recordSuccessfulDelivery(SignalMessageApp, userPhoneId);
   } catch (error) {
     await logError("Signal", "Error sending signal message", error);
     return false;
   }
   return true;
+}
+
+/**
+ * Send a menu as a native Signal poll and remember its options so an incoming
+ * vote can be mapped back to a menu action. Returns false on failure so the
+ * caller can fall back to a text menu.
+ */
+export async function sendSignalPollMenu(
+  signalCli: SignalCli,
+  userPhoneId: string,
+  title: string,
+  optionTexts: string[],
+  hasAccount?: boolean
+): Promise<boolean> {
+  try {
+    const options = optionTexts
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0)
+      .slice(0, SIGNAL_POLL_MAX_OPTIONS)
+      .map((t) =>
+        t.length > SIGNAL_POLL_OPTION_MAX_CHARS
+          ? t.slice(0, SIGNAL_POLL_OPTION_MAX_CHARS)
+          : t
+      );
+
+    // Signal polls require at least 2 options.
+    if (options.length < 2) return false;
+
+    const res = await signalCli.sendPollCreate({
+      question: title,
+      options,
+      multiSelect: false,
+      recipients: [toSignalRecipient(userPhoneId)]
+    });
+
+    // Map this poll's send timestamp to the exact options we sent.
+    registerPollMenu(res.timestamp, options);
+
+    umami.log({
+      event: "/message-sent",
+      messageApp: "Signal",
+      hasAccount
+    });
+
+    return true;
+  } catch (error) {
+    await logError("Signal", "Error sending signal poll menu", error);
+    return false;
+  }
+}
+
+/** Plain-text menu fallback when a poll cannot be sent. */
+async function sendSignalMenuFallbackText(
+  signalCli: SignalCli,
+  userPhoneId: string,
+  optionTexts: string[]
+): Promise<void> {
+  const body =
+    "Choisissez une option en recopiant l'un des boutons ci-dessous:\n\n" +
+    optionTexts.join("\n");
+  await signalCli.sendMessage(toSignalRecipient(userPhoneId), body);
 }

--- a/tests/signal.poll.test.ts
+++ b/tests/signal.poll.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { SignalCli } from "signal-sdk";
+import {
+  clearPollRegistry,
+  registerPollMenu,
+  resolvePollVote
+} from "../entities/SignalPollRegistry.ts";
+import { sendSignalPollMenu } from "../entities/SignalSession.ts";
+import { KEYBOARD_KEYS, POLL_MENU_KEYS } from "../entities/Keyboard.ts";
+
+/**
+ * Builds a fake SignalCli that records the PollCreateOptions it receives and
+ * returns a fixed timestamp, mimicking signal-cli's SendResponse.
+ */
+function fakeSignalCli(timestamp: number, opts?: { throws?: boolean }) {
+  const calls: {
+    question: string;
+    options: string[];
+    recipients?: string[];
+  }[] = [];
+  const messages: { recipient: string; body: string }[] = [];
+  const cli = {
+    sendPollCreate: (params: {
+      question: string;
+      options: string[];
+      recipients?: string[];
+    }) => {
+      if (opts?.throws) return Promise.reject(new Error("poll unsupported"));
+      calls.push(params);
+      return Promise.resolve({ timestamp, results: [] });
+    },
+    sendMessage: (recipient: string, body: string) => {
+      messages.push({ recipient, body });
+      return Promise.resolve({ timestamp, results: [] });
+    }
+  } as unknown as SignalCli;
+  return { cli, calls, messages };
+}
+
+describe("SignalPollRegistry", () => {
+  beforeEach(() => {
+    clearPollRegistry();
+  });
+
+  it("resolves a vote index back to the registered option label", () => {
+    registerPollMenu(1000, ["A", "B", "C"]);
+    expect(resolvePollVote(1000, [0])).toBe("A");
+    expect(resolvePollVote(1000, [2])).toBe("C");
+  });
+
+  it("returns undefined for an unknown poll timestamp", () => {
+    expect(resolvePollVote(424242, [0])).toBeUndefined();
+  });
+
+  it("returns undefined for an out-of-range or empty option index", () => {
+    registerPollMenu(2000, ["X", "Y"]);
+    expect(resolvePollVote(2000, [5])).toBeUndefined();
+    expect(resolvePollVote(2000, [])).toBeUndefined();
+  });
+
+  it("evicts the oldest entries beyond the size cap", () => {
+    // Cap is 500; insert 520 and confirm the earliest are gone, latest remain.
+    for (let i = 0; i < 520; i++)
+      registerPollMenu(i, [`opt-${String(i)}`, "other"]);
+    expect(resolvePollVote(0, [0])).toBeUndefined();
+    expect(resolvePollVote(10, [0])).toBeUndefined();
+    expect(resolvePollVote(519, [0])).toBe("opt-519");
+  });
+});
+
+describe("sendSignalPollMenu", () => {
+  beforeEach(() => {
+    clearPollRegistry();
+  });
+
+  it("sends a single-select poll and registers the options", async () => {
+    const { cli, calls } = fakeSignalCli(7777);
+    const ok = await sendSignalPollMenu(cli, "33123456789", "Menu", [
+      "First",
+      "Second",
+      "Third"
+    ]);
+
+    expect(ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].question).toBe("Menu");
+    expect(calls[0].options).toEqual(["First", "Second", "Third"]);
+    // recipient is normalised to +E.164
+    expect(calls[0].recipients).toEqual(["+33123456789"]);
+    // the mapping is stored under the returned send timestamp
+    expect(resolvePollVote(7777, [1])).toBe("Second");
+  });
+
+  it("clamps option labels to 100 characters", async () => {
+    const long = "x".repeat(150);
+    const { cli, calls } = fakeSignalCli(8888);
+    await sendSignalPollMenu(cli, "+33123456789", "Menu", [long, "ok"]);
+
+    expect(calls[0].options[0]).toHaveLength(100);
+    expect(resolvePollVote(8888, [0])).toHaveLength(100);
+  });
+
+  it("refuses to send a poll with fewer than 2 valid options", async () => {
+    const { cli, calls } = fakeSignalCli(9999);
+    const ok = await sendSignalPollMenu(cli, "+33123456789", "Menu", ["only"]);
+    expect(ok).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("returns false when the SDK rejects (so callers can fall back)", async () => {
+    const { cli } = fakeSignalCli(1234, { throws: true });
+    const ok = await sendSignalPollMenu(cli, "+33123456789", "Menu", [
+      "a",
+      "b"
+    ]);
+    expect(ok).toBe(false);
+    expect(resolvePollVote(1234, [0])).toBeUndefined();
+  });
+});
+
+describe("poll menu / keyboard parity", () => {
+  it("every poll option label maps to a KEYBOARD_KEYS command", () => {
+    const knownLabels = new Set(
+      Object.values(KEYBOARD_KEYS).map((k) => k.key.text)
+    );
+    for (const key of POLL_MENU_KEYS) {
+      // A resolved poll vote is dispatched by matching this exact text in
+      // processMessage, so each poll label must exist as a keyboard command.
+      expect(knownLabels.has(key.text)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## What

Makes the Signal integration comprehensive and gives it **poll-based menus, analogous to Matrix**.

### Poll menus
- Signal menus now render as native polls via `signalCli.sendPollCreate` (`sendSignalPollMenu` in `entities/SignalSession.ts`), mirroring Matrix's `sendPollMenu`.
- Incoming votes arrive as `envelope.dataMessage.pollVote` and are handled in `apps/signalApp.ts`: the selected option **index** is mapped back to its menu **label** through a new `entities/SignalPollRegistry.ts` (`pollTimestamp → options`), the poll is closed with `sendPollTerminate`, and the label is dispatched through the existing `processMessage` / `KEYBOARD_KEYS` router — no command-routing changes needed.
- Unlike Matrix (whose poll response carries the answer text), Signal returns numeric indexes, hence the small registry.

### Text fallback
- Gated by `SIGNAL_USE_POLLS` (default **on**). On poll-send failure or when disabled, falls back to the plain-text menu. The main menu keeps its text-command help; sub-menus fall back to a label list.

### Finished stubs
- Real message timestamp (`envelope.timestamp`) instead of `new Date()`.
- `sendTypingAction` → `signalCli.sendTyping`.
- Read receipts via `connect({ sendReadReceipts: true })`.

### Shared menu list
- Extracted `POLL_MENU_KEYS` into `entities/Keyboard.ts`; `MatrixSession` now reuses it (no behavior change). 7 options, under Signal's 10-option cap.

## Tests
`tests/signal.poll.test.ts`: registry resolve/evict, poll send + option clamping, `<2`-option and SDK-failure fallbacks, and poll-label/keyboard parity.

## Verification
- `tsc --noEmit` — clean
- `eslint .` — 0 problems
- `vitest run --coverage` — **174 passed (14 files)**
- Manual (needs a linked Signal device): `/start` → tap a poll option → command runs → poll closes; `SIGNAL_USE_POLLS=false` → text fallback. *Not run in this environment.*

## Config
`.env.template`: added `SIGNAL_USE_POLLS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)