### PR TITLE
feat(whatsapp): weekly re-engagement reminders + pending pile-up cap

### DIFF
--- a/commands/triggerPendingNotifications.ts
+++ b/commands/triggerPendingNotifications.ts
@@ -9,7 +9,10 @@ import { callJORFSearchReference } from "../utils/JORFSearch.utils.ts";
 import User from "../models/User.ts";
 import { Publication } from "../models/Publication.ts";
 
-const FETCH_CONCURRENCY = 1;
+// Pending refs are re-fetched from JORFSearch on re-engagement. A pending pile
+// can hold hundreds of refs, so fetch a few in parallel rather than serially.
+// callJORFSearchReference already retries with backoff on transient failures.
+const FETCH_CONCURRENCY = 4;
 
 export const triggerPendingNotifications = async (
   session: ISession

--- a/commands/triggerPendingNotifications.ts
+++ b/commands/triggerPendingNotifications.ts
@@ -114,7 +114,13 @@ export const triggerPendingNotifications = async (
 
     await User.updateOne(
       { _id: session.user._id },
-      { $set: { waitingReengagement: false, pendingNotifications: [] } }
+      {
+        $set: {
+          waitingReengagement: false,
+          pendingNotifications: [],
+          reengagementReminderCount: 0
+        }
+      }
     );
 
     const earliestInsertDate = session.user.pendingNotifications.reduce(

--- a/entities/WhatsAppSession.ts
+++ b/entities/WhatsAppSession.ts
@@ -58,7 +58,7 @@ export const WHATSAPP_NEAR_MISS_WINDOW_MS =
 export const REENGAGEMENT_REMINDER_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 export const MAX_REENGAGEMENT_REMINDERS = 8;
 
-const TEMPLATE_MESSAGE_COST_EUROS = 0.0248;
+export const TEMPLATE_MESSAGE_COST_EUROS = 0.0248;
 
 const WhatsAppMessageApp: MessageApp = "WhatsApp";
 
@@ -428,13 +428,20 @@ function replaceWHButtons(keyboard: Keyboard): Keyboard {
   );
 }
 
-const NOTIFICATION_TEMPLATE = "notification_meta";
+export const NOTIFICATION_TEMPLATE = "notification_meta";
+
+// Distinct "last nudge" template used on the final allowed reminder so the user
+// knows it's the last one. Falls back to the standard template when no separate
+// (approved) template is configured, preserving current behavior.
+export const FINAL_NOTIFICATION_TEMPLATE =
+  process.env.WHATSAPP_FINAL_NOTIFICATION_TEMPLATE ?? NOTIFICATION_TEMPLATE;
 
 export async function sendWhatsAppTemplate(
   whatsAppAPI: WhatsAppAPI,
   userInfo: ExtendedMiniUserInfo,
   notificationType: NotificationType,
   options: MessageSendingOptionsInternal,
+  templateName: string = NOTIFICATION_TEMPLATE,
   retryNumber = 0
 ): Promise<boolean> {
   const now = new Date();
@@ -459,7 +466,7 @@ export async function sendWhatsAppTemplate(
   }
 
   try {
-    const template_message = new Template(NOTIFICATION_TEMPLATE, "fr");
+    const template_message = new Template(templateName, "fr");
 
     const resp: ServerMessageResponse = await whatsAppAPI.sendMessage(
       WHATSAPP_PHONE_ID,
@@ -474,6 +481,7 @@ export async function sendWhatsAppTemplate(
           userInfo,
           notificationType,
           options,
+          templateName,
           nextRetryNumber
         );
       return await handleWhatsAppAPIErrors(

--- a/entities/WhatsAppSession.ts
+++ b/entities/WhatsAppSession.ts
@@ -53,6 +53,11 @@ export const WHATSAPP_REENGAGEMENT_TIMEOUT_WITH_MARGIN_MS =
 export const WHATSAPP_NEAR_MISS_WINDOW_MS =
   1000 * 60 * (24 * 60 + 5 * WHATSAPP_REENGAGEMENT_MARGIN_MINS);
 
+// Weekly re-engagement reminder for users with pending notifications.
+// Resend the template at most once per interval, capped per pending cycle.
+export const REENGAGEMENT_REMINDER_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+export const MAX_REENGAGEMENT_REMINDERS = 8;
+
 const TEMPLATE_MESSAGE_COST_EUROS = 0.0248;
 
 const WhatsAppMessageApp: MessageApp = "WhatsApp";
@@ -487,7 +492,11 @@ export async function sendWhatsAppTemplate(
     };
     await User.updateOne(
       { messageApp: "WhatsApp", chatId: userInfo.chatId },
-      { $push: { costHistory: costOperation } }
+      {
+        $push: { costHistory: costOperation },
+        $set: { lastReengagementSentAt: new Date() },
+        $inc: { reengagementReminderCount: 1 }
+      }
     );
 
     await umamiLogger({

--- a/models/User.ts
+++ b/models/User.ts
@@ -20,9 +20,17 @@ import { logError } from "../utils/debugLogger.ts";
 
 export const USER_SCHEMA_VERSION = 3;
 
-// Cap on pending notification records (source_ids) kept per user.
-// Oldest records are dropped when this limit is exceeded.
+// Cap on pending notification records (source_ids) kept per user for the broad
+// "function"/"organisation"/"meta" types. Oldest records are dropped past this.
 export const MAX_PENDING_NOTIFICATION_RECORDS = 300;
+
+// Capped-type pending records older than this are dropped: stale broad updates
+// are likely irrelevant by the time the user eventually re-engages.
+export const MAX_PENDING_AGE_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+
+// Safety net for the exempt "people"/"name" types: they are never aged-out, but
+// a pathological user can't grow them without bound. Far above any normal usage.
+export const MAX_PEOPLE_NAME_RECORDS = 2000;
 
 const escapeRegex = (value: string): string =>
   value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -704,43 +712,57 @@ UserSchema.static(
       items_nb
     };
 
-    // Build the full list (oldest first, new batch is newest) and keep only the
-    // latest MAX_PENDING_NOTIFICATION_RECORDS records, dropping oldest batches first.
-    // "people" and "name" follows are specific and must never be dropped, so they
-    // are always kept and excluded from the cap accounting.
+    // Build the full list (oldest first, new batch is newest) and walk it
+    // newest-first, keeping each type within its budget and dropping the oldest
+    // records beyond it. "people"/"name" follows are specific: never aged-out,
+    // only bounded by a large safety cap. Capped types are bounded by record
+    // count AND dropped once older than MAX_PENDING_AGE_MS.
     const fullList = [...user.pendingNotifications, newNotification];
     const trimmed: IUser["pendingNotifications"] = [];
-    let kept = 0;
+    const ageCutoffMs = now.getTime() - MAX_PENDING_AGE_MS;
+    let keptCapped = 0;
+    let keptExempt = 0;
+
+    // Keep only the newest `remaining` source_ids of a batch (proportional items_nb).
+    const sliceBatch = (
+      batch: IUser["pendingNotifications"][number],
+      remaining: number
+    ): IUser["pendingNotifications"][number] => {
+      const slicedIds = batch.source_ids.slice(
+        batch.source_ids.length - remaining
+      );
+      return {
+        ...batch,
+        source_ids: slicedIds,
+        items_nb: Math.round(
+          (batch.items_nb * remaining) / batch.source_ids.length
+        )
+      };
+    };
+
     for (let i = fullList.length - 1; i >= 0; i--) {
       const batch = fullList[i];
-
-      if (
+      const isExempt =
         batch.notificationType === "people" ||
-        batch.notificationType === "name"
-      ) {
-        trimmed.unshift(batch);
-        continue;
-      }
+        batch.notificationType === "name";
 
-      if (kept >= MAX_PENDING_NOTIFICATION_RECORDS) continue; // drop oldest capped batches
+      const budget = isExempt
+        ? MAX_PEOPLE_NAME_RECORDS - keptExempt
+        : MAX_PENDING_NOTIFICATION_RECORDS - keptCapped;
 
-      const remaining = MAX_PENDING_NOTIFICATION_RECORDS - kept;
-      if (batch.source_ids.length <= remaining) {
+      // Drop stale capped records, and anything beyond its type budget.
+      if (!isExempt && batch.insertDate.getTime() < ageCutoffMs) continue;
+      if (budget <= 0) continue;
+
+      if (batch.source_ids.length <= budget) {
         trimmed.unshift(batch);
-        kept += batch.source_ids.length;
+        if (isExempt) keptExempt += batch.source_ids.length;
+        else keptCapped += batch.source_ids.length;
       } else {
-        // boundary batch: keep only the newest `remaining` source_ids
-        const slicedIds = batch.source_ids.slice(
-          batch.source_ids.length - remaining
-        );
-        trimmed.unshift({
-          ...batch,
-          source_ids: slicedIds,
-          items_nb: Math.round(
-            (batch.items_nb * remaining) / batch.source_ids.length
-          )
-        });
-        kept += remaining;
+        // boundary batch: keep only the newest `budget` source_ids
+        trimmed.unshift(sliceBatch(batch, budget));
+        if (isExempt) keptExempt += budget;
+        else keptCapped += budget;
       }
     }
 
@@ -755,11 +777,12 @@ UserSchema.static(
   }
 );
 
-UserSchema.index({
-  messageApp: 1,
-  waitingReengagement: 1,
-  lastReengagementSentAt: 1
-});
+// Partial index: only docs waiting for re-engagement are indexed, keeping the
+// sweep query's index small (the vast majority of users are not waiting).
+UserSchema.index(
+  { messageApp: 1, lastReengagementSentAt: 1 },
+  { partialFilterExpression: { waitingReengagement: true } }
+);
 
 UserSchema.index({ "followedPeople.peopleId": 1 });
 UserSchema.index({ "followedFunctions.functionTag": 1 });

--- a/models/User.ts
+++ b/models/User.ts
@@ -20,6 +20,10 @@ import { logError } from "../utils/debugLogger.ts";
 
 export const USER_SCHEMA_VERSION = 3;
 
+// Cap on pending notification records (source_ids) kept per user.
+// Oldest records are dropped when this limit is exceeded.
+export const MAX_PENDING_NOTIFICATION_RECORDS = 300;
+
 const escapeRegex = (value: string): string =>
   value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
@@ -50,6 +54,8 @@ const UserSchema = new Schema<IUser, UserModel>(
       required: true
     },
     waitingReengagement: { type: Boolean, default: false, required: false },
+    lastReengagementSentAt: { type: Date, required: false },
+    reengagementReminderCount: { type: Number, default: 0, required: false },
     followedPeople: {
       type: [
         {
@@ -698,16 +704,62 @@ UserSchema.static(
       items_nb
     };
 
+    // Build the full list (oldest first, new batch is newest) and keep only the
+    // latest MAX_PENDING_NOTIFICATION_RECORDS records, dropping oldest batches first.
+    // "people" and "name" follows are specific and must never be dropped, so they
+    // are always kept and excluded from the cap accounting.
+    const fullList = [...user.pendingNotifications, newNotification];
+    const trimmed: IUser["pendingNotifications"] = [];
+    let kept = 0;
+    for (let i = fullList.length - 1; i >= 0; i--) {
+      const batch = fullList[i];
+
+      if (
+        batch.notificationType === "people" ||
+        batch.notificationType === "name"
+      ) {
+        trimmed.unshift(batch);
+        continue;
+      }
+
+      if (kept >= MAX_PENDING_NOTIFICATION_RECORDS) continue; // drop oldest capped batches
+
+      const remaining = MAX_PENDING_NOTIFICATION_RECORDS - kept;
+      if (batch.source_ids.length <= remaining) {
+        trimmed.unshift(batch);
+        kept += batch.source_ids.length;
+      } else {
+        // boundary batch: keep only the newest `remaining` source_ids
+        const slicedIds = batch.source_ids.slice(
+          batch.source_ids.length - remaining
+        );
+        trimmed.unshift({
+          ...batch,
+          source_ids: slicedIds,
+          items_nb: Math.round(
+            (batch.items_nb * remaining) / batch.source_ids.length
+          )
+        });
+        kept += remaining;
+      }
+    }
+
     await this.updateOne(
       { _id: userId },
       {
-        $push: {
-          pendingNotifications: newNotification
+        $set: {
+          pendingNotifications: trimmed
         }
       }
     );
   }
 );
+
+UserSchema.index({
+  messageApp: 1,
+  waitingReengagement: 1,
+  lastReengagementSentAt: 1
+});
 
 UserSchema.index({ "followedPeople.peopleId": 1 });
 UserSchema.index({ "followedFunctions.functionTag": 1 });

--- a/notifications/reengagementReminderSweep.ts
+++ b/notifications/reengagementReminderSweep.ts
@@ -6,12 +6,16 @@ import {
   ExternalMessageOptions
 } from "../entities/Session.ts";
 import {
+  FINAL_NOTIFICATION_TEMPLATE,
   MAX_REENGAGEMENT_REMINDERS,
+  NOTIFICATION_TEMPLATE,
   REENGAGEMENT_REMINDER_INTERVAL_MS,
   sendWhatsAppTemplate,
+  TEMPLATE_MESSAGE_COST_EUROS,
   WHATSAPP_API_SENDING_CONCURRENCY
 } from "../entities/WhatsAppSession.ts";
 import { logError } from "../utils/debugLogger.ts";
+import umami from "../utils/umami.ts";
 import pLimit from "p-limit";
 
 /**
@@ -66,7 +70,8 @@ export async function runReengagementReminderSweep(
       roomId: 1,
       status: 1,
       lastEngagementAt: 1,
-      waitingReengagement: 1
+      waitingReengagement: 1,
+      reengagementReminderCount: 1
     }
   ).lean();
 
@@ -78,34 +83,76 @@ export async function runReengagementReminderSweep(
 
   const limit = pLimit(WHATSAPP_API_SENDING_CONCURRENCY);
 
+  let sentCount = 0;
+  let failedCount = 0;
+
   await Promise.all(
     dueUsers.map((user) =>
       limit(async () => {
-        const userInfo: ExtendedMiniUserInfo = {
-          messageApp: "WhatsApp",
-          chatId: user.chatId,
-          roomId: user.roomId,
-          status: user.status,
-          hasAccount: true,
-          waitingReengagement: user.waitingReengagement,
-          lastEngagementAt: user.lastEngagementAt
-        };
+        try {
+          const userInfo: ExtendedMiniUserInfo = {
+            messageApp: "WhatsApp",
+            chatId: user.chatId,
+            roomId: user.roomId,
+            status: user.status,
+            hasAccount: true,
+            waitingReengagement: user.waitingReengagement,
+            lastEngagementAt: user.lastEngagementAt
+          };
 
-        // sendWhatsAppTemplate stamps lastReengagementSentAt and increments
-        // reengagementReminderCount on success (see WhatsAppSession.ts).
-        const sent = await sendWhatsAppTemplate(
-          whatsAppAPI,
-          userInfo,
-          "meta",
-          messageAppsOptions
-        );
-        if (!sent) {
+          // Last allowed nudge uses the distinct "final" template so the user
+          // knows it's the last one before the bot goes quiet.
+          const isFinalReminder =
+            (user.reengagementReminderCount ?? 0) + 1 >=
+            MAX_REENGAGEMENT_REMINDERS;
+          const templateName = isFinalReminder
+            ? FINAL_NOTIFICATION_TEMPLATE
+            : NOTIFICATION_TEMPLATE;
+
+          // sendWhatsAppTemplate stamps lastReengagementSentAt and increments
+          // reengagementReminderCount on success (see WhatsAppSession.ts).
+          const sent = await sendWhatsAppTemplate(
+            whatsAppAPI,
+            userInfo,
+            "meta",
+            messageAppsOptions,
+            templateName
+          );
+          if (sent) {
+            sentCount++;
+          } else {
+            failedCount++;
+            await logError(
+              "WhatsApp",
+              `Re-engagement reminder template failed for user ${user._id.toString()}`
+            );
+          }
+        } catch (error) {
+          // Isolate failures so one bad send doesn't abort the whole sweep.
+          failedCount++;
           await logError(
             "WhatsApp",
-            `Re-engagement reminder template failed for user ${user._id.toString()}`
+            `Re-engagement reminder threw for user ${user._id.toString()}`,
+            error
           );
         }
       })
     )
   );
+
+  const totalCost = sentCount * TEMPLATE_MESSAGE_COST_EUROS;
+  console.log(
+    `Re-engagement reminder sweep done: ${String(sentCount)} sent, ${String(failedCount)} failed, est. cost €${totalCost.toFixed(2)}.`
+  );
+  await umami.logAsync({
+    event: "/reengagement-reminder-sweep",
+    messageApp: "WhatsApp",
+    hasAccount: true,
+    payload: {
+      due: dueUsers.length,
+      sent: sentCount,
+      failed: failedCount,
+      cost_eur: totalCost
+    }
+  });
 }

--- a/notifications/reengagementReminderSweep.ts
+++ b/notifications/reengagementReminderSweep.ts
@@ -1,0 +1,111 @@
+import "dotenv/config";
+import User from "../models/User.ts";
+import { IUser } from "../types.ts";
+import {
+  ExtendedMiniUserInfo,
+  ExternalMessageOptions
+} from "../entities/Session.ts";
+import {
+  MAX_REENGAGEMENT_REMINDERS,
+  REENGAGEMENT_REMINDER_INTERVAL_MS,
+  sendWhatsAppTemplate,
+  WHATSAPP_API_SENDING_CONCURRENCY
+} from "../entities/WhatsAppSession.ts";
+import { logError } from "../utils/debugLogger.ts";
+import pLimit from "p-limit";
+
+/**
+ * Weekly re-engagement reminder sweep for WhatsApp users with pending
+ * notifications. Resends the re-engagement template (reopening the 24h window)
+ * to users who haven't engaged, at most once per REENGAGEMENT_REMINDER_INTERVAL_MS,
+ * and at most MAX_REENGAGEMENT_REMINDERS times per pending cycle.
+ *
+ * The reminder count is per pending cycle: it starts at 0 (reset on re-engagement
+ * in triggerPendingNotifications), so legacy pending users get a fresh cycle from
+ * the moment this feature ships.
+ */
+export async function runReengagementReminderSweep(
+  messageAppsOptions: ExternalMessageOptions
+): Promise<void> {
+  const whatsAppAPI = messageAppsOptions.whatsAppAPI;
+  if (whatsAppAPI == null) {
+    await logError(
+      "WhatsApp",
+      "runReengagementReminderSweep skipped: WhatsApp client is not set"
+    );
+    return;
+  }
+
+  const reminderCutoff = new Date(
+    Date.now() - REENGAGEMENT_REMINDER_INTERVAL_MS
+  );
+
+  const dueUsers: IUser[] = await User.find(
+    {
+      messageApp: "WhatsApp",
+      status: "active",
+      waitingReengagement: true,
+      "pendingNotifications.0": { $exists: true },
+      $and: [
+        {
+          $or: [
+            { reengagementReminderCount: { $exists: false } },
+            { reengagementReminderCount: { $lt: MAX_REENGAGEMENT_REMINDERS } }
+          ]
+        },
+        {
+          $or: [
+            { lastReengagementSentAt: { $exists: false } },
+            { lastReengagementSentAt: { $lte: reminderCutoff } }
+          ]
+        }
+      ]
+    },
+    {
+      chatId: 1,
+      roomId: 1,
+      status: 1,
+      lastEngagementAt: 1,
+      waitingReengagement: 1
+    }
+  ).lean();
+
+  if (dueUsers.length === 0) return;
+
+  console.log(
+    `Re-engagement reminder sweep: ${String(dueUsers.length)} WhatsApp user(s) due.`
+  );
+
+  const limit = pLimit(WHATSAPP_API_SENDING_CONCURRENCY);
+
+  await Promise.all(
+    dueUsers.map((user) =>
+      limit(async () => {
+        const userInfo: ExtendedMiniUserInfo = {
+          messageApp: "WhatsApp",
+          chatId: user.chatId,
+          roomId: user.roomId,
+          status: user.status,
+          hasAccount: true,
+          waitingReengagement: user.waitingReengagement,
+          lastEngagementAt: user.lastEngagementAt
+        };
+
+        // sendWhatsAppTemplate stamps lastReengagementSentAt and increments
+        // reengagementReminderCount on success (see WhatsAppSession.ts).
+        const sent = await sendWhatsAppTemplate(
+          whatsAppAPI,
+          userInfo,
+          "meta",
+          messageAppsOptions
+        );
+        if (!sent) {
+          await logError(
+            "WhatsApp",
+            `Re-engagement reminder template failed for user ${user._id.toString()}`
+          );
+        }
+      })
+    )
+  );
+}

--- a/notifications/runNotificationProcess.ts
+++ b/notifications/runNotificationProcess.ts
@@ -8,6 +8,7 @@ import { notifyPeopleUpdates } from "./peopleNotifications.ts";
 import { notifyNameMentionUpdates } from "./nameNotifications.ts";
 import { notifyFunctionTagsUpdates } from "./functionTagNotifications.ts";
 import { notifyAlertStringUpdates } from "./alertStringNotifications.ts";
+import { runReengagementReminderSweep } from "./reengagementReminderSweep.ts";
 import umami from "../utils/umami.ts";
 import mongoose, { Types } from "mongoose";
 
@@ -128,6 +129,11 @@ export async function runNotificationProcess(
       targetApps,
       messageAppsOptions
     );
+
+    // Weekly reminder for WhatsApp users sitting on pending notifications.
+    if (targetApps.includes("WhatsApp")) {
+      await runReengagementReminderSweep(messageAppsOptions);
+    }
 
     const duration_s = Math.ceil(
       (new Date().getTime() - start.getTime()) / 1000

--- a/tests/06.user.notifications.test.ts
+++ b/tests/06.user.notifications.test.ts
@@ -1,7 +1,27 @@
 import { describe, expect, beforeEach, it } from "vitest";
 import mongoose, { Types } from "mongoose";
-import User, { USER_SCHEMA_VERSION } from "../models/User.ts";
+import User, {
+  MAX_PENDING_NOTIFICATION_RECORDS,
+  USER_SCHEMA_VERSION
+} from "../models/User.ts";
 import { NotificationType, JORFReference } from "../types.ts";
+
+// Build `count` unique refs starting at `start`, e.g. JORFTEXT000123
+const makeRefs = (start: number, count: number): JORFReference[] => {
+  const refs: JORFReference[] = [];
+  for (let i = start; i < start + count; i++)
+    refs.push(`JORFTEXT${i.toString().padStart(6, "0")}`);
+  return refs;
+};
+
+const cappedRecordCount = (
+  notifs: { notificationType: NotificationType; source_ids: JORFReference[] }[]
+): number =>
+  notifs
+    .filter(
+      (n) => n.notificationType !== "people" && n.notificationType !== "name"
+    )
+    .reduce((sum, n) => sum + n.source_ids.length, 0);
 
 const makeUser = () =>
   User.create({
@@ -133,5 +153,115 @@ describe("User — insertPendingNotifications", () => {
     const refreshed = await User.findById(user._id);
     if (!refreshed) throw new Error("User not found");
     expect(refreshed.pendingNotifications.length).toBe(0);
+  });
+});
+
+describe("User — insertPendingNotifications record cap", () => {
+  beforeEach(async () => {
+    if (!mongoose.connection.db)
+      throw new Error("MongoDB connection not established");
+    await mongoose.connection.db.dropDatabase();
+  });
+
+  it("keeps only the latest MAX_PENDING_NOTIFICATION_RECORDS capped records", async () => {
+    const user = await makeUser();
+    const cap = MAX_PENDING_NOTIFICATION_RECORDS;
+
+    // 4 batches of cap/3 unique refs each -> 4/3 * cap total, oldest batch dropped
+    const per = Math.floor(cap / 3);
+    let cursor = 0;
+    for (let b = 0; b < 4; b++) {
+      await User.insertPendingNotifications(
+        user._id,
+        "Telegram",
+        "function",
+        makeSourceMap(makeRefs(cursor, per), 1)
+      );
+      cursor += per;
+    }
+
+    const refreshed = await User.findById(user._id);
+    if (!refreshed) throw new Error("User not found");
+
+    expect(
+      cappedRecordCount(refreshed.pendingNotifications)
+    ).toBeLessThanOrEqual(cap);
+
+    const allRefs = refreshed.pendingNotifications.flatMap((n) => n.source_ids);
+    // Oldest ref dropped, newest ref kept
+    expect(allRefs).not.toContain("JORFTEXT000000");
+    expect(allRefs).toContain(
+      makeRefs(cursor - 1, 1)[0] // last inserted ref
+    );
+  });
+
+  it("trims the boundary batch's source_ids when partially over the cap", async () => {
+    const user = await makeUser();
+    const cap = MAX_PENDING_NOTIFICATION_RECORDS;
+
+    // older batch (cap-50) then newer batch (100) -> total cap+50, keep newest cap
+    await User.insertPendingNotifications(
+      user._id,
+      "Telegram",
+      "function",
+      makeSourceMap(makeRefs(0, cap - 50), 1)
+    );
+    await User.insertPendingNotifications(
+      user._id,
+      "Telegram",
+      "function",
+      makeSourceMap(makeRefs(cap, 100), 1)
+    );
+
+    const refreshed = await User.findById(user._id);
+    if (!refreshed) throw new Error("User not found");
+    expect(cappedRecordCount(refreshed.pendingNotifications)).toBe(cap);
+  });
+
+  it("never drops people or name notifications, even over the cap", async () => {
+    const user = await makeUser();
+    const cap = MAX_PENDING_NOTIFICATION_RECORDS;
+
+    const peopleRefs = makeRefs(0, 50);
+    const nameRefs = makeRefs(1000, 40);
+
+    await User.insertPendingNotifications(
+      user._id,
+      "Telegram",
+      "people",
+      makeSourceMap(peopleRefs, 1)
+    );
+    await User.insertPendingNotifications(
+      user._id,
+      "Telegram",
+      "name",
+      makeSourceMap(nameRefs, 1)
+    );
+
+    // Flood with capped-type records well beyond the cap
+    let cursor = 5000;
+    const per = Math.floor(cap / 2);
+    for (let b = 0; b < 4; b++) {
+      await User.insertPendingNotifications(
+        user._id,
+        "Telegram",
+        "function",
+        makeSourceMap(makeRefs(cursor, per), 1)
+      );
+      cursor += per;
+    }
+
+    const refreshed = await User.findById(user._id);
+    if (!refreshed) throw new Error("User not found");
+
+    const allRefs = refreshed.pendingNotifications.flatMap((n) => n.source_ids);
+    // All people + name refs survive
+    for (const ref of [...peopleRefs, ...nameRefs])
+      expect(allRefs).toContain(ref);
+
+    // Capped types still bounded
+    expect(
+      cappedRecordCount(refreshed.pendingNotifications)
+    ).toBeLessThanOrEqual(cap);
   });
 });

--- a/tests/06.user.notifications.test.ts
+++ b/tests/06.user.notifications.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, beforeEach, it } from "vitest";
 import mongoose, { Types } from "mongoose";
 import User, {
+  MAX_PENDING_AGE_MS,
   MAX_PENDING_NOTIFICATION_RECORDS,
   USER_SCHEMA_VERSION
 } from "../models/User.ts";
@@ -263,5 +264,51 @@ describe("User — insertPendingNotifications record cap", () => {
     expect(
       cappedRecordCount(refreshed.pendingNotifications)
     ).toBeLessThanOrEqual(cap);
+  });
+
+  it("drops capped records older than MAX_PENDING_AGE_MS, keeps exempt ones", async () => {
+    const staleDate = new Date(Date.now() - MAX_PENDING_AGE_MS - 60_000);
+    const staleFunctionRefs = makeRefs(0, 10);
+    const stalePeopleRefs = makeRefs(2000, 10);
+
+    const user = await User.create({
+      chatId: "notif-chat-" + Math.random().toString(36).slice(2),
+      messageApp: "Telegram",
+      schemaVersion: USER_SCHEMA_VERSION,
+      pendingNotifications: [
+        {
+          notificationType: "function",
+          source_ids: staleFunctionRefs,
+          insertDate: staleDate,
+          items_nb: staleFunctionRefs.length
+        },
+        {
+          notificationType: "people",
+          source_ids: stalePeopleRefs,
+          insertDate: staleDate,
+          items_nb: stalePeopleRefs.length
+        }
+      ]
+    });
+
+    // Inserting a fresh batch triggers the trim pass.
+    const freshRefs = makeRefs(5000, 5);
+    await User.insertPendingNotifications(
+      user._id,
+      "Telegram",
+      "function",
+      makeSourceMap(freshRefs, 1)
+    );
+
+    const refreshed = await User.findById(user._id);
+    if (!refreshed) throw new Error("User not found");
+    const allRefs = refreshed.pendingNotifications.flatMap((n) => n.source_ids);
+
+    // Stale capped batch dropped
+    for (const ref of staleFunctionRefs) expect(allRefs).not.toContain(ref);
+    // Stale exempt (people) batch never aged-out
+    for (const ref of stalePeopleRefs) expect(allRefs).toContain(ref);
+    // Fresh batch kept
+    for (const ref of freshRefs) expect(allRefs).toContain(ref);
   });
 });

--- a/tests/09.reengagement.sweep.test.ts
+++ b/tests/09.reengagement.sweep.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import mongoose from "mongoose";
+
+// Spy for the template sender so no real WhatsApp API / cooldown runs.
+const { sendSpy } = vi.hoisted(() => ({ sendSpy: vi.fn() }));
+
+vi.mock("../entities/WhatsAppSession.ts", async (importActual) => {
+  const actual =
+    await importActual<typeof import("../entities/WhatsAppSession.ts")>();
+  return {
+    ...actual,
+    sendWhatsAppTemplate: (...args: unknown[]): Promise<boolean> =>
+      sendSpy(...args) as Promise<boolean>
+  };
+});
+
+vi.mock("../utils/umami.ts", () => ({
+  default: { log: vi.fn(), logAsync: vi.fn() }
+}));
+
+import User, { USER_SCHEMA_VERSION } from "../models/User.ts";
+import type { ExternalMessageOptions } from "../entities/Session.ts";
+import { runReengagementReminderSweep } from "../notifications/reengagementReminderSweep.ts";
+import {
+  FINAL_NOTIFICATION_TEMPLATE,
+  MAX_REENGAGEMENT_REMINDERS,
+  NOTIFICATION_TEMPLATE
+} from "../entities/WhatsAppSession.ts";
+
+const EIGHT_DAYS_MS = 8 * 24 * 60 * 60 * 1000;
+
+const fakeOptions = {
+  whatsAppAPI: {} as unknown
+} as ExternalMessageOptions;
+
+let counter = 0;
+const createWAUser = (overrides: Record<string, unknown> = {}) =>
+  User.create({
+    chatId: `wh-${String(counter++)}`,
+    messageApp: "WhatsApp",
+    schemaVersion: USER_SCHEMA_VERSION,
+    status: "active",
+    waitingReengagement: true,
+    lastEngagementAt: new Date(Date.now() - EIGHT_DAYS_MS),
+    pendingNotifications: [
+      {
+        notificationType: "function",
+        source_ids: ["JORFTEXT000001"],
+        insertDate: new Date(),
+        items_nb: 1
+      }
+    ],
+    ...overrides
+  });
+
+// chatIds passed to the (mocked) template sender
+const sentChatIds = (): string[] =>
+  sendSpy.mock.calls.map((c) => (c[1] as { chatId: string }).chatId);
+
+describe("runReengagementReminderSweep", () => {
+  beforeEach(async () => {
+    if (!mongoose.connection.db)
+      throw new Error("MongoDB connection not established");
+    await mongoose.connection.db.dropDatabase();
+    sendSpy.mockReset();
+    sendSpy.mockResolvedValue(true);
+    counter = 0;
+  });
+
+  it("sends only to due users", async () => {
+    const due = await createWAUser();
+    await createWAUser({ waitingReengagement: false }); // not waiting
+    await createWAUser({ pendingNotifications: [] }); // nothing pending
+    await createWAUser({ status: "blocked" }); // blocked
+    await createWAUser({ lastReengagementSentAt: new Date() }); // reminded just now
+    await createWAUser({
+      reengagementReminderCount: MAX_REENGAGEMENT_REMINDERS
+    }); // cap reached
+
+    await runReengagementReminderSweep(fakeOptions);
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sentChatIds()).toEqual([due.chatId]);
+  });
+
+  it("includes users last reminded over a week ago", async () => {
+    const due = await createWAUser({
+      lastReengagementSentAt: new Date(Date.now() - EIGHT_DAYS_MS),
+      reengagementReminderCount: 3
+    });
+
+    await runReengagementReminderSweep(fakeOptions);
+
+    expect(sentChatIds()).toEqual([due.chatId]);
+  });
+
+  it("uses the final template on the last allowed reminder", async () => {
+    await createWAUser({
+      reengagementReminderCount: MAX_REENGAGEMENT_REMINDERS - 1
+    });
+
+    await runReengagementReminderSweep(fakeOptions);
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    // 5th positional arg is templateName
+    expect(sendSpy.mock.calls[0][4]).toBe(FINAL_NOTIFICATION_TEMPLATE);
+  });
+
+  it("uses the standard template before the last reminder", async () => {
+    await createWAUser({ reengagementReminderCount: 0 });
+
+    await runReengagementReminderSweep(fakeOptions);
+
+    expect(sendSpy.mock.calls[0][4]).toBe(NOTIFICATION_TEMPLATE);
+  });
+
+  it("does nothing when the WhatsApp client is missing", async () => {
+    await createWAUser();
+
+    await runReengagementReminderSweep({});
+
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+
+  it("continues the sweep when one send throws", async () => {
+    await createWAUser();
+    await createWAUser();
+    sendSpy.mockRejectedValueOnce(new Error("boom"));
+
+    await runReengagementReminderSweep(fakeOptions);
+
+    // Both users attempted despite the first throwing
+    expect(sendSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -59,6 +59,8 @@ export interface IUser {
   language_code: string;
   status: "active" | "blocked";
   waitingReengagement: boolean;
+  lastReengagementSentAt?: Date;
+  reengagementReminderCount?: number;
   followedPeople: {
     peopleId: Types.ObjectId;
     lastUpdate: Date;

--- a/utils/messageWorkflow.ts
+++ b/utils/messageWorkflow.ts
@@ -23,9 +23,18 @@ export async function handleIncomingMessage(
   const { beforeProcessing, isReply, errorContext, isFirstMessage } =
     options ?? {};
   try {
+    // Any inbound reopens the 24h window: clear re-engagement state so a future
+    // pending cycle starts fresh (reminder cadence + cap reset from here).
     const res = await User.updateOne(
       { messageApp: session.messageApp, chatId: session.chatId },
-      { $set: { lastEngagementAt: session.lastEngagementAt, status: "active" } }
+      {
+        $set: {
+          lastEngagementAt: session.lastEngagementAt,
+          status: "active",
+          waitingReengagement: false,
+          reengagementReminderCount: 0
+        }
+      }
     );
     session.log({
       event: "/message-received",

--- a/utils/umami.ts
+++ b/utils/umami.ts
@@ -127,6 +127,7 @@ export type UmamiEvent =
   | "/message-fail-too-many-requests-aborted"
   | "/message-received-echo-refused"
   | "/reengagement-notifications-sent"
+  | "/reengagement-reminder-sweep"
   | "/wh-reengagement-near-miss"
   | "/trigger-pending-updates"
   | "/start"


### PR DESCRIPTION
## Problem

WhatsApp users with a pending notification got a single re-engagement template, then nothing — forever. Two issues:
- **Abandoned users:** once `waitingReengagement=true`, the template never resent; a user who forgot was never reminded again.
- **Unbounded pile-up:** pending records accumulated with no cap (100s/day → thousands over a year), also blowing up the eventual re-fetch on re-engagement.

## Changes

**Weekly reminder**
- New `runReengagementReminderSweep` runs in the daily WhatsApp job. Resends the template to users with pending notifications, once per 7 days, capped at 8 reminders per pending cycle. Per-user interval → naturally weekly, staggered.
- Cap counts from this feature shipping (`reengagementReminderCount` defaults 0), so legacy pending users get a fresh cycle.
- Last allowed nudge uses a distinct, env-configurable template (`WHATSAPP_FINAL_NOTIFICATION_TEMPLATE`), falling back to the standard one.

**Pile-up cap**
- `insertPendingNotifications` keeps only the latest 300 records for the broad `function`/`organisation`/`meta` types, and drops those older than 90 days.
- `people`/`name` follows are specific and exempt from the cap/age-out (soft safety cap of 2000 against pathological growth).

**Hardening**
- New `lastReengagementSentAt` / `reengagementReminderCount` fields, stamped on every template send (one place), reset on any inbound that reopens the 24h window.
- Partial index on `waitingReengagement` for a cheap sweep query.
- Faster pending re-fetch on re-engagement (`FETCH_CONCURRENCY` 1→4).
- Per-user failure isolation + cost observability (sent/failed/€ + umami event) in the sweep.

## Tests

- `insertPendingNotifications` cap, boundary slicing, age-drop, people/name exemption.
- Sweep: due-user selection, interval gating, final-vs-standard template, missing-client no-op, failure isolation.
- Full suite: 344 tests pass. `lint`, `build` clean.

## Follow-ups (ops)
- Add `WHATSAPP_FINAL_NOTIFICATION_TEMPLATE` to `.env.template` and get the "last nudge" template approved by Meta. Until then it safely reuses the standard template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)