### PR TITLE
fix(messaging): resume from failed chunk instead of resending whole message (WhatsApp #131056)

### DIFF
--- a/entities/SignalSession.ts
+++ b/entities/SignalSession.ts
@@ -15,6 +15,11 @@ const SignalMessageApp: MessageApp = "Signal";
 
 export const SIGNAL_MESSAGE_CHAR_LIMIT = 2000;
 const SIGNAL_COOL_DOWN_DELAY_SECONDS = 6;
+// signal-sdk exposes no error taxonomy, so a send failure is treated as transient:
+// resume from the failed chunk for a few capped-backoff attempts, then give up
+// (return false -> notification retried on a later run, user state unchanged).
+const MAX_SIGNAL_MESSAGE_RETRY = 3;
+const SIGNAL_MAX_BACKOFF_MS = 60_000;
 
 export const SIGNAL_API_SENDING_CONCURRENCY = 1;
 
@@ -111,19 +116,27 @@ export async function sendSignalAppMessage(
   signalCli: SignalCli,
   userPhoneId: string,
   message: string,
-  options: MessageSendingOptionsInternal
+  options: MessageSendingOptionsInternal,
+  retryNumber = 0,
+  // Resume state for retries: reuse the already-split chunks and start at the
+  // failed chunk so previously delivered chunks are not resent.
+  preSplitChunks?: string[],
+  startChunk = 0
 ): Promise<boolean> {
   const umamiLogger: UmamiLogger = options.useAsyncUmamiLog
     ? umami.logAsync
     : umami.log;
+  const userPhoneIdInt = userPhoneId.startsWith("+")
+    ? userPhoneId
+    : "+" + userPhoneId;
+  // On a retry, reuse the chunks split on the first attempt (don't re-convert).
+  const mArr =
+    preSplitChunks ??
+    splitText(markdown2plainText(message), SIGNAL_MESSAGE_CHAR_LIMIT);
+  let i = startChunk;
   try {
-    const cleanMessage = markdown2plainText(message);
-    const userPhoneIdInt = userPhoneId.startsWith("+")
-      ? userPhoneId
-      : "+" + userPhoneId;
-    const mArr = splitText(cleanMessage, SIGNAL_MESSAGE_CHAR_LIMIT);
-    for (const elem of mArr) {
-      await signalCli.sendMessage(userPhoneIdInt, elem);
+    for (; i < mArr.length; i++) {
+      await signalCli.sendMessage(userPhoneIdInt, mArr[i]);
 
       await umamiLogger({
         event: "/message-sent",
@@ -138,7 +151,27 @@ export async function sendSignalAppMessage(
     }
     await recordSuccessfulDelivery(SignalMessageApp, userPhoneId);
   } catch (error) {
-    await logError("Signal", "Error sending signal message", error);
+    if (retryNumber < MAX_SIGNAL_MESSAGE_RETRY) {
+      const backoffMs =
+        Math.min(Math.pow(2, retryNumber) * 1000, SIGNAL_MAX_BACKOFF_MS) +
+        Math.random() * 1000;
+      await new Promise((resolve) => setTimeout(resolve, backoffMs));
+      // Resume from the failed chunk i, reusing mArr.
+      return await sendSignalAppMessage(
+        signalCli,
+        userPhoneId,
+        message,
+        options,
+        retryNumber + 1,
+        mArr,
+        i
+      );
+    }
+    await logError(
+      "Signal",
+      `Error sending signal message aborted after ${String(MAX_SIGNAL_MESSAGE_RETRY)} retries (chunk ${String(i + 1)}/${String(mArr.length)}) to ${userPhoneId}`,
+      error
+    );
     return false;
   }
   return true;

--- a/entities/WhatsAppSession.ts
+++ b/entities/WhatsAppSession.ts
@@ -37,6 +37,9 @@ const WHATSAPP_BURST_MODE_DELAY_SECONDS = 0.5; // Minimum delay between messages
 const WHATSAPP_BURST_MODE_THRESHOLD = 10; // Number of messages to send in burst mode, before switching to full cooldown
 
 const MAX_MESSAGE_RETRY = 5;
+// Cap the exponential backoff so a single send can't hold a dispatch slot for
+// minutes (4^5 = 1024s uncapped). Jitter de-syncs concurrent retries.
+const MAX_BACKOFF_MS = 60_000;
 
 export const WHATSAPP_API_SENDING_CONCURRENCY = 80; // 80 messages per second global
 
@@ -237,7 +240,15 @@ export async function sendWhatsAppMessage(
   userInfo: ExtendedMiniUserInfo,
   message: string,
   options: MessageSendingOptionsInternal,
-  retryNumber = 0
+  retryNumber = 0,
+  // Resume state for retries: when a chunk send fails, the retry re-enters with
+  // the already-split/already-converted chunks (preSplitChunks) and the index of
+  // the failed chunk (startChunk), so previously delivered chunks are NOT resent.
+  // Resending the whole message from chunk 0 duplicated delivered chunks and
+  // amplified the pair rate limit (#131056). startChunk >= chunks.length skips the
+  // chunk loop entirely and resumes at the separate menu message.
+  preSplitChunks?: string[],
+  startChunk = 0
 ): Promise<boolean> {
   // Judge the window against the run-wide snapshot when the notification path
   // supplies one, so this guard agrees with the routing decision the handler
@@ -304,16 +315,20 @@ export async function sendWhatsAppMessage(
   }
 
   let resp: ServerMessageResponse;
-  const mArr = splitText(
-    markdown2WHMarkdown(message),
-    WHATSAPP_MESSAGE_CHAR_LIMIT,
-    WHATSAPP_MAX_LINES
-  );
+  // On a retry, reuse the chunks split on the first attempt. Re-splitting here
+  // would re-run markdown2WHMarkdown on already-converted text (double conversion).
+  const mArr =
+    preSplitChunks ??
+    splitText(
+      markdown2WHMarkdown(message),
+      WHATSAPP_MESSAGE_CHAR_LIMIT,
+      WHATSAPP_MAX_LINES
+    );
 
   const totalMessages = mArr.length + (options.separateMenuMessage ? 1 : 0);
   const burstMode = totalMessages <= WHATSAPP_BURST_MODE_THRESHOLD; // Limit cooldown if less than 10
 
-  let i = 0;
+  let i = startChunk;
   try {
     for (; i < mArr.length; i++) {
       if (
@@ -342,13 +357,17 @@ export async function sendWhatsAppMessage(
         );
       }
       if (resp.error) {
+        // Resume from the failed chunk i, reusing mArr (no re-split/re-convert).
+        const failedChunk = i;
         const retryFunction = (nextRetryNumber: number) =>
           sendWhatsAppMessage(
             whatsAppAPI,
             userInfo,
             message,
             options,
-            nextRetryNumber
+            nextRetryNumber,
+            mArr,
+            failedChunk
           );
         return await handleWhatsAppAPIErrors(
           { errorCode: resp.error.code, rawError: resp.error },
@@ -392,13 +411,17 @@ export async function sendWhatsAppMessage(
         );
       }
       if (resp.error) {
+        // The chunks already sent; resume at the separate menu (skip chunk loop)
+        // by starting past the last chunk so we don't resend delivered chunks.
         const retryFunction = (nextRetryNumber: number) =>
           sendWhatsAppMessage(
             whatsAppAPI,
             userInfo,
             message,
             options,
-            nextRetryNumber
+            nextRetryNumber,
+            mArr,
+            mArr.length
           );
         return await handleWhatsAppAPIErrors(
           { errorCode: resp.error.code, rawError: resp.error },
@@ -582,7 +605,7 @@ export async function handleWhatsAppAPIErrors(
     case 131048:
     case 131056:
       if (retryParameters != null) {
-        if (retryParameters.retryNumber > MAX_MESSAGE_RETRY) {
+        if (retryParameters.retryNumber >= MAX_MESSAGE_RETRY) {
           await umamiLogger({
             event: "/message-fail-too-many-requests-aborted",
             messageApp: "WhatsApp"
@@ -598,9 +621,13 @@ export async function handleWhatsAppAPIErrors(
           event: "/message-fail-too-many-requests",
           messageApp: "WhatsApp"
         });
-        await new Promise((resolve) =>
-          setTimeout(resolve, Math.pow(4, retryParameters.retryNumber) * 1000)
-        );
+        const backoffMs =
+          Math.min(
+            Math.pow(4, retryParameters.retryNumber) * 1000,
+            MAX_BACKOFF_MS
+          ) +
+          Math.random() * 1000;
+        await new Promise((resolve) => setTimeout(resolve, backoffMs));
         return await retryParameters.retryFunction(
           retryParameters.retryNumber + 1
         );

--- a/tests/14.messageResendResume.test.ts
+++ b/tests/14.messageResendResume.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// WhatsAppSession reads WHATSAPP_PHONE_ID at module load (vi.hoisted runs first).
+vi.hoisted(() => {
+  process.env.WHATSAPP_PHONE_ID = "TEST_PHONE_ID";
+});
+
+// Keep analytics + DB writes inert. handleWhatsAppAPIErrors and
+// recordSuccessfulDelivery both touch the User model; stub it so the send path
+// runs without a database.
+vi.mock("../utils/umami.ts", () => ({
+  default: { log: vi.fn(), logAsync: vi.fn() }
+}));
+vi.mock("../models/User.ts", () => ({
+  default: {
+    findOne: vi.fn(() => ({ lean: () => Promise.resolve(null) })),
+    updateOne: vi.fn(() => Promise.resolve({}))
+  }
+}));
+
+import { sendWhatsAppMessage } from "../entities/WhatsAppSession.ts";
+import { sendSignalAppMessage } from "../entities/SignalSession.ts";
+import { markdown2WHMarkdown, splitText } from "../utils/text.utils.ts";
+import {
+  WHATSAPP_MESSAGE_CHAR_LIMIT,
+  WHATSAPP_MAX_LINES
+} from "../entities/WhatsAppSession.ts";
+import { SIGNAL_MESSAGE_CHAR_LIMIT } from "../entities/SignalSession.ts";
+import type { ExtendedMiniUserInfo } from "../entities/Session.ts";
+import type { WhatsAppAPI } from "whatsapp-api-js/middleware/express";
+import type { SignalCli } from "signal-sdk";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+const waUser = (): ExtendedMiniUserInfo => ({
+  messageApp: "WhatsApp",
+  // In window: lastEngagement just now so the re-engagement guard lets us through.
+  chatId: "resume-" + Math.random().toString(36).slice(2),
+  status: "active",
+  hasAccount: true,
+  waitingReengagement: false,
+  lastEngagementAt: new Date(Date.now() - 1 * HOUR_MS)
+});
+
+// A long, multi-line body that splits into several WhatsApp chunks.
+const longBody = Array.from(
+  { length: 60 },
+  (_, n) => `line number ${String(n)} with some filler content to add length`
+).join("\n");
+
+// Make all setTimeout-based sleeps (cooldowns + retry backoff) instant, and
+// record the delays so we can assert the backoff cap.
+let recordedDelays: number[] = [];
+beforeEach(() => {
+  recordedDelays = [];
+  vi.stubGlobal("setTimeout", (fn: () => void, ms?: number) => {
+    recordedDelays.push(ms ?? 0);
+    fn();
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  });
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("sendWhatsAppMessage — resume from failed chunk", () => {
+  it("on a transient mid-message failure, resumes from the failed chunk without resending delivered chunks", async () => {
+    const chunks = splitText(
+      markdown2WHMarkdown(longBody),
+      WHATSAPP_MESSAGE_CHAR_LIMIT,
+      WHATSAPP_MAX_LINES
+    );
+    expect(chunks.length).toBeGreaterThanOrEqual(3);
+
+    // Fail exactly once, on the 3rd send (chunk index 2's first attempt) with a
+    // transient pair-rate-limit (131056); succeed on every other call.
+    let n = 0;
+    const sendMessage = vi.fn(() => {
+      n++;
+      if (n === 3) return Promise.resolve({ error: { code: 131056 } });
+      return Promise.resolve({ messages: [{ id: "ok" }] });
+    });
+    const api = { sendMessage } as unknown as WhatsAppAPI;
+
+    const res = await sendWhatsAppMessage(api, waUser(), longBody, {
+      hasAccount: true,
+      useAsyncUmamiLog: false
+    });
+
+    expect(res).toBe(true);
+    // Resume: chunks 0..1 sent once, chunk 2 sent twice (fail+retry), rest once.
+    // => total = chunks.length + 1. The old whole-resend bug would have produced
+    // chunks.length + (failed index) extra sends (>= chunks.length + 2).
+    expect(sendMessage).toHaveBeenCalledTimes(chunks.length + 1);
+  });
+
+  it("caps retry backoff and aborts after exactly MAX_MESSAGE_RETRY (5) retries", async () => {
+    // Single-chunk message that always fails with a transient code.
+    const sendMessage = vi.fn(() =>
+      Promise.resolve({ error: { code: 131056 } })
+    );
+    const api = { sendMessage } as unknown as WhatsAppAPI;
+
+    const res = await sendWhatsAppMessage(api, waUser(), "short message", {
+      hasAccount: true,
+      useAsyncUmamiLog: false
+    });
+
+    expect(res).toBe(false);
+    // Initial attempt + 5 retries = 6 sends, then abort.
+    expect(sendMessage).toHaveBeenCalledTimes(6);
+    // Every backoff (and cooldown) stayed under the cap + max jitter. Uncapped
+    // 4^5 backoff would have been 1_024_000ms.
+    expect(Math.max(...recordedDelays)).toBeLessThanOrEqual(60_000 + 1000);
+  });
+});
+
+describe("sendSignalAppMessage — resume from failed chunk", () => {
+  // Distinct per-chunk content so we can detect a duplicated chunk by value.
+  const signalBody =
+    "A".repeat(SIGNAL_MESSAGE_CHAR_LIMIT) +
+    "B".repeat(SIGNAL_MESSAGE_CHAR_LIMIT) +
+    "C".repeat(100); // 3 chunks
+
+  it("resumes from the failed chunk instead of losing the remainder", async () => {
+    const chunks = splitText(signalBody, SIGNAL_MESSAGE_CHAR_LIMIT);
+    expect(chunks.length).toBeGreaterThanOrEqual(3);
+
+    const sentTexts: string[] = [];
+    let n = 0;
+    const send = vi.fn((_phone: string, text: string) => {
+      n++;
+      sentTexts.push(text);
+      if (n === 2) return Promise.reject(new Error("transient signal error"));
+      return Promise.resolve({});
+    });
+    const signalCli = { sendMessage: send } as unknown as SignalCli;
+
+    const res = await sendSignalAppMessage(
+      signalCli,
+      "33600000000",
+      signalBody,
+      {
+        useAsyncUmamiLog: false,
+        hasAccount: true
+      }
+    );
+
+    expect(res).toBe(true);
+    // chunk0 once, chunk1 twice (fail+retry), chunk2 once => chunks.length + 1.
+    expect(send).toHaveBeenCalledTimes(chunks.length + 1);
+    // The first chunk was delivered exactly once (no duplicate on resume).
+    expect(sentTexts.filter((t) => t === chunks[0])).toHaveLength(1);
+  });
+
+  it("gives up (false) after exhausting retries on persistent failure", async () => {
+    const send = vi.fn(() =>
+      Promise.reject(new Error("persistent signal error"))
+    );
+    const signalCli = { sendMessage: send } as unknown as SignalCli;
+
+    const res = await sendSignalAppMessage(signalCli, "33600000000", "short", {
+      useAsyncUmamiLog: false,
+      hasAccount: true
+    });
+
+    expect(res).toBe(false);
+    // Initial attempt + MAX_SIGNAL_MESSAGE_RETRY (3) retries = 4 sends.
+    expect(send).toHaveBeenCalledTimes(4);
+  });
+});


### PR DESCRIPTION
## Context

Production alert: WhatsApp sends to a recipient failed repeatedly with **error 131056** — "(Business Account, Consumer Account) pair rate limit hit … too many messages sent from this phone number to the same phone number in a short period."

Audit found the retry logic was **self-amplifying** the rate limit, plus two hygiene bugs.

## Root causes

1. **Whole-message resend.** On a per-chunk send error, the WhatsApp retry re-invoked `sendWhatsAppMessage` with the original full `message`, resending already-delivered chunks to the same pair → more messages → worse 131056.
2. **Uncapped backoff.** `4^retryNumber` reached `4^5 = 1024s`; total hold ≈ 1365s (~22 min) per message, blocking a `pLimit(80)` dispatch slot.
3. **Off-by-one.** Abort boundary `retryNumber > 5` ran 6 retries while logging "after 5 retries".

## Cross-app audit

Only WhatsApp had the whole-resend bug. **Telegram** and **Matrix/Tchap** already resume from the failed chunk (`mArr.slice(i)`) — left untouched. **Signal** had **no retry at all** — a mid-message chunk failure silently dropped the remainder.

## Changes

- **WhatsApp** (`entities/WhatsAppSession.ts`): retry resumes from the failed chunk via new internal `preSplitChunks`/`startChunk` params, reusing the already-split/already-converted `mArr` (avoids re-running `markdown2WHMarkdown` → double conversion). Separate-menu failure resumes past the chunk loop. Backoff capped at 60s + jitter; off-by-one fixed (`>= MAX_MESSAGE_RETRY`); 131056 kept retryable (now safe).
- **Signal** (`entities/SignalSession.ts`): added resume-from-failed-chunk with capped backoff + jitter for transient errors; gives up to `false` after 3 retries (user state unchanged → retried on a later run).
- **Tests** (`tests/14.messageResendResume.test.ts`): WhatsApp no-duplicate-chunk on transient retry, capped backoff + exactly 5 retries, Signal resume, Signal give-up.

Billing note: coalescing free-form messages was considered and **rejected** — under Meta PMP pricing (since 2025-07-01) free-form/session messages are already free and the re-engagement template is already deduped across handlers, so it gives no billing benefit.

## Verification

- `npx tsc --noEmit` — clean
- `vitest run --coverage` — 206 tests pass (202 existing + 4 new)
- `eslint` — clean

## Out of scope (follow-ups)

- Per-recipient coalesce/cooldown (deferred — no billing benefit; retry fix tames 131056).
- `NOTIFICATIONS_SHIFT_DAYS=0` silent cross-run drop of transient failures.
- `triggerPendingNotifications` clears the pending queue even when a replay send fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)