### PR TITLE
fix(ci): publish coverage badge to a badges branch

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,0 @@
-{"schemaVersion":1,"label":"coverage","message":"38.97%","color":"red"}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,14 +29,16 @@ jobs:
       - name: Generate coverage badge
         run: npx tsx scripts/coverage-badge.ts
 
-      - name: Commit badge if changed
+      # main is protected, so the badge is published to a dedicated, orphan
+      # `badges` branch (force-updated) instead of committed back to main.
+      - name: Publish badge to the badges branch
         run: |
-          if ! git diff --quiet -- .github/badges/coverage.json; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add .github/badges/coverage.json
-            git commit -m "chore(badge): update coverage badge [skip ci]"
-            git push
-          else
-            echo "Coverage badge unchanged."
-          fi
+          cp .github/badges/coverage.json "$RUNNER_TEMP/coverage.json"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout --orphan badges
+          git rm -rf . > /dev/null 2>&1 || true
+          cp "$RUNNER_TEMP/coverage.json" coverage.json
+          git add coverage.json
+          git commit -m "chore(badge): update coverage badge [skip ci]"
+          git push -f origin badges

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ dist/
 /matrix/
 coverage-summary.json
 /coverage/
+
+# Coverage badge is generated in CI and published to the badges branch
+.github/badges/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![TypeScript](https://badges.frapsoft.com/typescript/code/typescript.svg?v=101)](https://github.com/microsoft/TypeScript)
 [![Lint](https://github.com/fabrahaingo/joel/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/fabrahaingo/joel/actions/workflows/lint.yml)
 [![Tests](https://github.com/fabrahaingo/joel/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/fabrahaingo/joel/actions/workflows/tests.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/fabrahaingo/joel/main/.github/badges/coverage.json)](https://github.com/fabrahaingo/joel/actions/workflows/coverage.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/fabrahaingo/joel/badges/coverage.json)](https://github.com/fabrahaingo/joel/actions/workflows/coverage.yml)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 <br />
 [![NodeJS](https://img.shields.io/badge/node.js-6DA55F?style=for-the-badge&logo=node.js&logoColor=white)](https://nodejs.org)


### PR DESCRIPTION
The Coverage workflow committed the badge back to `main`, which is a protected branch → push rejected (`GH006`).

Publish the badge to a dedicated orphan `badges` branch (force-updated) instead, and point the README shields endpoint at `raw.githubusercontent.com/fabrahaingo/joel/badges/coverage.json`. The badge JSON is generated in CI and git-ignored locally; the stale seed file is removed.

Follow-up to #309 (that PR merged just before this fix was pushed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)