### PR TITLE
chore(signal): Coolify SERVICE_FQDN for QR-link access

### DIFF
--- a/docker-compose.signal.yml
+++ b/docker-compose.signal.yml
@@ -5,6 +5,11 @@ services:
     image: bbernhard/signal-cli-rest-api:latest
     environment:
       - MODE=json-rpc # persistent daemon; enables the WebSocket receive endpoint
+      # Coolify fills this in and routes a generated domain to port 8080, so the
+      # QR-link endpoint is reachable. NOTE: signal-cli-rest-api has no auth —
+      # anyone with the URL can send/read as your number. Use it only to link
+      # the device, then remove the domain (the bot reaches the API internally).
+      - SERVICE_FQDN_SIGNALAPI_8080
     # Internal only — the bot reaches this over the compose network. To link a
     # device, route a domain to this service's port 8080 in Coolify (or publish
     # 8080 temporarily) and open /v1/qrcodelink. Avoids a host-port clash.


### PR DESCRIPTION
Adds the Coolify magic env var `SERVICE_FQDN_SIGNALAPI_8080` to the `signal-api`
service so Coolify routes a generated domain to port 8080 — needed to reach the
`/v1/qrcodelink` device-linking endpoint (Coolify "Links" was empty because the
service only used `expose`).

signal-cli-rest-api is unauthenticated, so the compose comment warns to remove
the domain after linking; the bot itself reaches the API over the internal
compose network and needs no public link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)