### PR TITLE
fix(signal): rename service to signalapi so Coolify FQDN routes

### DIFF
--- a/docker-compose.signal.yml
+++ b/docker-compose.signal.yml
@@ -1,7 +1,12 @@
 # JOEL Signal deployment: the bot plus the signal-cli daemon (REST + WebSocket).
 # Used both locally and as the Coolify deploy unit.
+#
+# The service is named "signalapi" (no hyphen) on purpose: Coolify derives its
+# magic-variable identifier from the service name, and a hyphen/underscore
+# identifier can't carry the "_8080" port suffix — so SERVICE_FQDN_SIGNALAPI_8080
+# would never route. A single-token name keeps the generated domain working.
 services:
-  signal-api:
+  signalapi:
     image: bbernhard/signal-cli-rest-api:latest
     environment:
       - MODE=json-rpc # persistent daemon; enables the WebSocket receive endpoint
@@ -10,9 +15,9 @@ services:
       # anyone with the URL can send/read as your number. Use it only to link
       # the device, then remove the domain (the bot reaches the API internally).
       - SERVICE_FQDN_SIGNALAPI_8080
-    # Internal only — the bot reaches this over the compose network. To link a
-    # device, route a domain to this service's port 8080 in Coolify (or publish
-    # 8080 temporarily) and open /v1/qrcodelink. Avoids a host-port clash.
+    # Internal only — the bot reaches this over the compose network. Coolify
+    # routes the generated domain to this port for one-time device linking via
+    # /v1/qrcodelink. No host port, so no clash on shared hosts.
     expose:
       - "8080"
     volumes:
@@ -25,13 +30,13 @@ services:
       context: .
       dockerfile: Dockerfile.signal
     environment:
-      - SIGNAL_API_URL=http://signal-api:8080
+      - SIGNAL_API_URL=http://signalapi:8080
     env_file:
       - .env
     depends_on:
       # wait until signal-cli-rest-api is healthy so the bot's first WebSocket
       # connect doesn't race the daemon's startup.
-      signal-api:
+      signalapi:
         condition: service_healthy
     restart: unless-stopped
 


### PR DESCRIPTION
Follow-up to #312. The Coolify magic var `SERVICE_FQDN_SIGNALAPI_8080` produced no link because Coolify derives the identifier from the compose service name: `signal-api` becomes an underscore identifier, and per Coolify docs an underscore identifier cannot carry the `_8080` port suffix — so no domain was generated ("No links available").

Rename the service to the single token `signalapi` (updating `SIGNAL_API_URL` and `depends_on` accordingly) so the port suffix parses and the QR-link domain is created. The `signal-data` volume name is unchanged, so linked-device keys persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)