### PR TITLE
fix(whatsapp): tame 131056 rate-limit noise and de-dup outage alerts

### DIFF
--- a/entities/WhatsAppSession.ts
+++ b/entities/WhatsAppSession.ts
@@ -25,7 +25,7 @@ import { markdown2WHMarkdown, splitText } from "../utils/text.utils.ts";
 import { deleteUserAndCleanup } from "../utils/userDeletion.utils.ts";
 import { Keyboard, KEYBOARD_KEYS, KeyboardKey } from "./Keyboard.ts";
 import { MAIN_MENU_MESSAGE } from "../commands/default.ts";
-import { logError } from "../utils/debugLogger.ts";
+import { logError, logWarning } from "../utils/debugLogger.ts";
 import { timeDaysBetweenDates } from "../utils/date.utils.ts";
 
 export const WHATSAPP_MESSAGE_CHAR_LIMIT = 900;
@@ -232,7 +232,64 @@ export async function extractWhatsAppSession(
 
 const { WHATSAPP_PHONE_ID } = process.env;
 
+// Per-recipient send serialization. Meta enforces a pair rate limit (#131056)
+// when too many messages hit one number in a short window; overlapping sends to
+// the same chatId from independent flows (notification run, a manual command,
+// the re-engagement sweep) are the main trigger. This in-process promise-chain
+// mutex serializes sends per chatId so at most one is in flight to a given
+// number at a time. Orthogonal to WHATSAPP_API_SENDING_CONCURRENCY, which caps
+// total throughput across all recipients. Single-instance deployment assumed.
+const recipientSendChains = new Map<string, Promise<unknown>>();
+
+async function withRecipientLock<T>(
+  chatId: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const prev = recipientSendChains.get(chatId) ?? Promise.resolve();
+  // Run once the previous send to this chatId settles, regardless of its outcome.
+  const run = prev.then(fn, fn);
+  const tail = run.then(
+    () => undefined,
+    () => undefined
+  );
+  recipientSendChains.set(chatId, tail);
+  // Bound Map growth: drop the entry once this is the settled tail (i.e. no newer
+  // send has chained on behind it).
+  void tail.then(() => {
+    if (recipientSendChains.get(chatId) === tail) {
+      recipientSendChains.delete(chatId);
+    }
+  });
+  return run;
+}
+
+// Public entry: acquires the per-recipient lock, then runs the send. The retry
+// path re-enters sendWhatsAppMessageInner directly (already holding the lock),
+// so a rate-limited user's backoff holds the lock — intended back-pressure — and
+// never deadlocks by re-acquiring.
 export async function sendWhatsAppMessage(
+  whatsAppAPI: WhatsAppAPI,
+  userInfo: ExtendedMiniUserInfo,
+  message: string,
+  options: MessageSendingOptionsInternal,
+  retryNumber = 0,
+  preSplitChunks?: string[],
+  startChunk = 0
+): Promise<boolean> {
+  return withRecipientLock(userInfo.chatId, () =>
+    sendWhatsAppMessageInner(
+      whatsAppAPI,
+      userInfo,
+      message,
+      options,
+      retryNumber,
+      preSplitChunks,
+      startChunk
+    )
+  );
+}
+
+async function sendWhatsAppMessageInner(
   whatsAppAPI: WhatsAppAPI,
   userInfo: ExtendedMiniUserInfo,
   message: string,
@@ -366,7 +423,7 @@ export async function sendWhatsAppMessage(
         // Resume from the failed chunk i, reusing mArr (no re-split/re-convert).
         const failedChunk = i;
         const retryFunction = (nextRetryNumber: number) =>
-          sendWhatsAppMessage(
+          sendWhatsAppMessageInner(
             whatsAppAPI,
             userInfo,
             message,
@@ -421,7 +478,7 @@ export async function sendWhatsAppMessage(
         // The chunks already sent; resume at the separate menu (skip chunk loop)
         // by starting past the last chunk so we don't resend delivered chunks.
         const retryFunction = (nextRetryNumber: number) =>
-          sendWhatsAppMessage(
+          sendWhatsAppMessageInner(
             whatsAppAPI,
             userInfo,
             message,
@@ -501,6 +558,28 @@ export async function sendWhatsAppTemplate(
   templateName: string = NOTIFICATION_TEMPLATE,
   retryNumber = 0
 ): Promise<boolean> {
+  // Share the per-recipient lock with sendWhatsAppMessage so a re-engagement
+  // template and a notification to the same number never fire simultaneously.
+  return withRecipientLock(userInfo.chatId, () =>
+    sendWhatsAppTemplateInner(
+      whatsAppAPI,
+      userInfo,
+      notificationType,
+      options,
+      templateName,
+      retryNumber
+    )
+  );
+}
+
+async function sendWhatsAppTemplateInner(
+  whatsAppAPI: WhatsAppAPI,
+  userInfo: ExtendedMiniUserInfo,
+  notificationType: NotificationType,
+  options: MessageSendingOptionsInternal,
+  templateName: string = NOTIFICATION_TEMPLATE,
+  retryNumber = 0
+): Promise<boolean> {
   const now = new Date();
   if (
     now.getTime() - userInfo.lastEngagementAt.getTime() <
@@ -533,7 +612,7 @@ export async function sendWhatsAppTemplate(
 
     if (resp.error) {
       const retryFunction = (nextRetryNumber: number) =>
-        sendWhatsAppTemplate(
+        sendWhatsAppTemplateInner(
           whatsAppAPI,
           userInfo,
           notificationType,
@@ -618,7 +697,14 @@ export async function handleWhatsAppAPIErrors(
             event: "/message-fail-too-many-requests-aborted",
             messageApp: "WhatsApp"
           });
-          await logError(
+          // Pair rate limits (131056) and per-user throughput limits (131048) are
+          // expected transient conditions, not faults — log them as warnings so
+          // they don't read as errors in the debug channel. Genuine transient
+          // outages (2, 4, 80007, 130429) stay at error severity.
+          const isExpectedRateLimit =
+            error.errorCode === 131056 || error.errorCode === 131048;
+          const logAbort = isExpectedRateLimit ? logWarning : logError;
+          await logAbort(
             "WhatsApp",
             `WH API error ${String(error.errorCode)} aborted after ${String(MAX_MESSAGE_RETRY)} retries in ${callerFunctionLabel} to ${chatId}`,
             error.rawError ?? undefined

--- a/tests/18.whatsappSession.extra.test.ts
+++ b/tests/18.whatsappSession.extra.test.ts
@@ -16,7 +16,10 @@ const { logErrorSpy, deleteSpy, userState, findOrCreateSpy } = vi.hoisted(
 vi.mock("../utils/umami.ts", () => ({
   default: { log: vi.fn(), logAsync: vi.fn() }
 }));
-vi.mock("../utils/debugLogger.ts", () => ({ logError: logErrorSpy }));
+vi.mock("../utils/debugLogger.ts", () => ({
+  logError: logErrorSpy,
+  logWarning: vi.fn(() => Promise.resolve())
+}));
 vi.mock("../utils/userDeletion.utils.ts", () => ({
   deleteUserAndCleanup: deleteSpy
 }));

--- a/tests/48.debugLogger.dedup.test.ts
+++ b/tests/48.debugLogger.dedup.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// debugLogger captures DEBUG_CHAT_ID / TELEGRAM_DEBUG_BOT_TOKEN into module-level
+// consts at import time, so they must be set before the module loads.
+vi.hoisted(() => {
+  process.env.DEBUG_CHAT_ID = "12345";
+  process.env.TELEGRAM_DEBUG_BOT_TOKEN = "debug-bot-token-abcdefgh";
+});
+
+vi.mock("axios", () => {
+  const post = vi.fn(() => Promise.resolve({ data: {} }));
+  const get = vi.fn(() => Promise.resolve({ data: {} }));
+  const instance = { post, get };
+  return {
+    default: {
+      post,
+      get,
+      create: vi.fn(() => instance),
+      isAxiosError: () => false
+    }
+  };
+});
+vi.mock("../utils/umami.ts", () => ({
+  default: { log: vi.fn(), logAsync: vi.fn() }
+}));
+
+import axios from "axios";
+import { logError, resetAlertDedupState } from "../utils/debugLogger.ts";
+
+const post = axios.post as unknown as ReturnType<typeof vi.fn>;
+
+let nowMs = 1_000_000;
+
+beforeEach(() => {
+  process.env.DEBUG_ALERT_DEDUP_WINDOW_SECONDS = "300";
+  resetAlertDedupState();
+  post.mockClear();
+  nowMs = 1_000_000;
+  vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+  // Make the inter-message cooldown sleep instant.
+  vi.stubGlobal("setTimeout", (fn: () => void) => {
+    fn();
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("debug alert de-duplication", () => {
+  it("suppresses identical-signature alerts within the window (digits normalized)", async () => {
+    // Same message, different chatId/counts — digits are stripped for the signature.
+    await logError(
+      "WhatsApp",
+      "WH API error 131056 aborted after 5 retries in sendWhatsAppMessage to 33678613826"
+    );
+    await logError(
+      "WhatsApp",
+      "WH API error 131056 aborted after 5 retries in sendWhatsAppMessage to 33111111111"
+    );
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-alerts after the window elapses, prefixing the suppressed count", async () => {
+    await logError("WhatsApp", "JORFSearch request for people aborted after 5 tries");
+    await logError("WhatsApp", "JORFSearch request for people aborted after 5 tries");
+    await logError("WhatsApp", "JORFSearch request for people aborted after 5 tries");
+    expect(post).toHaveBeenCalledTimes(1);
+
+    nowMs += 301_000; // just past the 300s window
+    await logError("WhatsApp", "JORFSearch request for people aborted after 5 tries");
+    expect(post).toHaveBeenCalledTimes(2);
+
+    const secondText = (post.mock.calls[1][1] as { text: string }).text;
+    expect(secondText).toContain("2 similar suppressed");
+  });
+
+  it("does not suppress alerts with distinct signatures", async () => {
+    await logError("WhatsApp", "First distinct alert alpha");
+    await logError("WhatsApp", "Second distinct alert beta");
+    expect(post).toHaveBeenCalledTimes(2);
+  });
+
+  it("respects the DEBUG_ALERT_DEDUP_WINDOW_SECONDS override", async () => {
+    process.env.DEBUG_ALERT_DEDUP_WINDOW_SECONDS = "60";
+    await logError("WhatsApp", "override window test gamma");
+    nowMs += 61_000; // past the 60s override window
+    await logError("WhatsApp", "override window test gamma");
+    expect(post).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/48.debugLogger.dedup.test.ts
+++ b/tests/48.debugLogger.dedup.test.ts
@@ -64,13 +64,25 @@ describe("debug alert de-duplication", () => {
   });
 
   it("re-alerts after the window elapses, prefixing the suppressed count", async () => {
-    await logError("WhatsApp", "JORFSearch request for people aborted after 5 tries");
-    await logError("WhatsApp", "JORFSearch request for people aborted after 5 tries");
-    await logError("WhatsApp", "JORFSearch request for people aborted after 5 tries");
+    await logError(
+      "WhatsApp",
+      "JORFSearch request for people aborted after 5 tries"
+    );
+    await logError(
+      "WhatsApp",
+      "JORFSearch request for people aborted after 5 tries"
+    );
+    await logError(
+      "WhatsApp",
+      "JORFSearch request for people aborted after 5 tries"
+    );
     expect(post).toHaveBeenCalledTimes(1);
 
     nowMs += 301_000; // just past the 300s window
-    await logError("WhatsApp", "JORFSearch request for people aborted after 5 tries");
+    await logError(
+      "WhatsApp",
+      "JORFSearch request for people aborted after 5 tries"
+    );
     expect(post).toHaveBeenCalledTimes(2);
 
     const secondText = (post.mock.calls[1][1] as { text: string }).text;

--- a/tests/49.whatsappRateLimitHandling.test.ts
+++ b/tests/49.whatsappRateLimitHandling.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// WhatsAppSession reads WHATSAPP_PHONE_ID at module load.
+vi.hoisted(() => {
+  process.env.WHATSAPP_PHONE_ID = "TEST_PHONE_ID";
+});
+
+vi.mock("../utils/debugLogger.ts", () => ({
+  logError: vi.fn(() => Promise.resolve()),
+  logWarning: vi.fn(() => Promise.resolve())
+}));
+vi.mock("../utils/umami.ts", () => ({
+  default: { log: vi.fn(), logAsync: vi.fn() }
+}));
+vi.mock("../models/User.ts", () => ({
+  default: {
+    findOne: vi.fn(() => ({ lean: () => Promise.resolve(null) })),
+    updateOne: vi.fn(() => Promise.resolve({}))
+  }
+}));
+
+import {
+  handleWhatsAppAPIErrors,
+  sendWhatsAppMessage
+} from "../entities/WhatsAppSession.ts";
+import { logError, logWarning } from "../utils/debugLogger.ts";
+import type { ExtendedMiniUserInfo } from "../entities/Session.ts";
+import type { WhatsAppAPI } from "whatsapp-api-js/middleware/express";
+
+const logErrorMock = logError as unknown as ReturnType<typeof vi.fn>;
+const logWarningMock = logWarning as unknown as ReturnType<typeof vi.fn>;
+
+const HOUR_MS = 60 * 60 * 1000;
+const MAX_MESSAGE_RETRY = 5;
+
+const waUser = (): ExtendedMiniUserInfo => ({
+  messageApp: "WhatsApp",
+  chatId: "lock-" + Math.random().toString(36).slice(2),
+  status: "active",
+  hasAccount: true,
+  waitingReengagement: false,
+  lastEngagementAt: new Date(Date.now() - 1 * HOUR_MS)
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Make cooldown/backoff sleeps instant.
+  vi.stubGlobal("setTimeout", (fn: () => void) => {
+    fn();
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  });
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("handleWhatsAppAPIErrors — rate-limit severity", () => {
+  it("logs a 131056 abort as a warning, not an error", async () => {
+    const res = await handleWhatsAppAPIErrors(
+      { errorCode: 131056 },
+      "sendWhatsAppMessage",
+      "33678613826",
+      vi.fn(() => Promise.resolve()),
+      { retryFunction: vi.fn(), retryNumber: MAX_MESSAGE_RETRY }
+    );
+    expect(res).toBe(false);
+    expect(logWarningMock).toHaveBeenCalledTimes(1);
+    expect(logErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("logs a 131048 abort as a warning", async () => {
+    await handleWhatsAppAPIErrors(
+      { errorCode: 131048 },
+      "sendWhatsAppMessage",
+      "33600000000",
+      vi.fn(() => Promise.resolve()),
+      { retryFunction: vi.fn(), retryNumber: MAX_MESSAGE_RETRY }
+    );
+    expect(logWarningMock).toHaveBeenCalledTimes(1);
+    expect(logErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps a genuine transient (130429) abort at error severity", async () => {
+    await handleWhatsAppAPIErrors(
+      { errorCode: 130429 },
+      "sendWhatsAppMessage",
+      "33600000000",
+      vi.fn(() => Promise.resolve()),
+      { retryFunction: vi.fn(), retryNumber: MAX_MESSAGE_RETRY }
+    );
+    expect(logErrorMock).toHaveBeenCalledTimes(1);
+    expect(logWarningMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendWhatsAppMessage — per-recipient serialization", () => {
+  const opts = { hasAccount: true, useAsyncUmamiLog: false };
+
+  it("serializes concurrent sends to the same chatId", async () => {
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    const gate = new Promise<void>((r) => {
+      releaseFirst = r;
+    });
+    let call = 0;
+    const sendMessage = vi.fn(async () => {
+      call++;
+      const id = call;
+      events.push(`start${String(id)}`);
+      if (id === 1) await gate; // hold the first send open
+      events.push(`end${String(id)}`);
+      return { messages: [{ id: "ok" }] };
+    });
+    const api = { sendMessage } as unknown as WhatsAppAPI;
+    const user = waUser(); // same chatId for both sends
+
+    const p1 = sendWhatsAppMessage(api, user, "m1", opts);
+    const p2 = sendWhatsAppMessage(api, user, "m2", opts);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    // The second send must not have started while the first holds the lock.
+    expect(events).toEqual(["start1"]);
+
+    releaseFirst();
+    await Promise.all([p1, p2]);
+    expect(events).toEqual(["start1", "end1", "start2", "end2"]);
+  });
+
+  it("allows concurrent sends to different chatIds", async () => {
+    const events: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const sendMessage = vi.fn(async () => {
+      events.push("start");
+      await gate;
+      return { messages: [{ id: "ok" }] };
+    });
+    const api = { sendMessage } as unknown as WhatsAppAPI;
+
+    const p1 = sendWhatsAppMessage(api, waUser(), "m", opts);
+    const p2 = sendWhatsAppMessage(api, waUser(), "m", opts);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    // Different recipients run in parallel — both in flight before either resolves.
+    expect(events.filter((e) => e === "start")).toHaveLength(2);
+
+    release();
+    await Promise.all([p1, p2]);
+  });
+});

--- a/utils/debugLogger.ts
+++ b/utils/debugLogger.ts
@@ -12,6 +12,34 @@ type LogLevel = "warning" | "error";
 const DEBUG_CHAT_ID = process.env.DEBUG_CHAT_ID;
 const TELEGRAM_DEBUG_BOT_TOKEN = process.env.TELEGRAM_DEBUG_BOT_TOKEN;
 
+const DEFAULT_ALERT_DEDUP_WINDOW_SECONDS = 300; // 5 min
+
+// Read at call-time (not module load) so the window can be tuned via env without
+// a restart, and so tests can override it.
+const getDedupWindowSeconds = (): number => {
+  const raw = process.env.DEBUG_ALERT_DEDUP_WINDOW_SECONDS;
+  const parsed = raw != null ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_ALERT_DEDUP_WINDOW_SECONDS;
+};
+
+// Collapse the volatile parts of an alert (chatIds, counts, timestamps — all
+// digits) so repeats of the "same" alert during an outage share one key.
+const alertSignature = (text: string): string => text.replace(/\d+/g, "#");
+
+// In-memory de-dup state, keyed by alert signature. Only the Telegram send is
+// throttled — console logging (upstream, in logToConsole) is never suppressed.
+const alertDedupState = new Map<
+  string,
+  { lastSentAt: number; suppressed: number }
+>();
+
+// Exposed for tests: clears the in-memory de-dup state between cases.
+export const resetAlertDedupState = (): void => {
+  alertDedupState.clear();
+};
+
 /**
  * Replaces all `process.env` values (with at least 8 characters) found in the
  * given string with their variable name as a placeholder (e.g. `<TELEGRAM_BOT_TOKEN>`).
@@ -127,10 +155,28 @@ export const sendTelegramDebugMessage = async (text: string): Promise<void> => {
     return;
   }
 
+  // De-dup: during an outage the same alert fires once per affected user/request.
+  // Suppress repeats of an identical-signature alert within the window; surface
+  // the suppressed count on the next alert that gets through.
+  const windowSeconds = getDedupWindowSeconds();
+  const signature = alertSignature(text);
+  const now = Date.now();
+  const prev = alertDedupState.get(signature);
+  if (prev != null && now - prev.lastSentAt < windowSeconds * 1000) {
+    prev.suppressed += 1;
+    return;
+  }
+  let outText = text;
+  if (prev != null && prev.suppressed > 0) {
+    const windowMinutes = Math.max(1, Math.round(windowSeconds / 60));
+    outText = `(${String(prev.suppressed)} similar suppressed in last ${String(windowMinutes)}m)\n${text}`;
+  }
+  alertDedupState.set(signature, { lastSentAt: now, suppressed: 0 });
+
   const endpoint = `https://api.telegram.org/bot${TELEGRAM_DEBUG_BOT_TOKEN}/sendMessage`;
 
   try {
-    const mArr = splitText(text, TELEGRAM_MESSAGE_CHAR_LIMIT);
+    const mArr = splitText(outText, TELEGRAM_MESSAGE_CHAR_LIMIT);
 
     for (const m of mArr) {
       await axios.post(endpoint, {


### PR DESCRIPTION
## Context

Two production conditions surfaced in the Jarvis_JOEL Telegram debug channel:

1. **JORFSearch `aborted after 5 tries` — `ECONNREFUSED`**: an external provider outage. The code already degrades correctly, but during an outage **every** user request emits an identical alert, flooding the channel.
2. **WhatsApp `131056` pair rate limit**: expected transient condition (concurrent sends to the same number across flows), yet logged as an error after the retry budget.

## Changes

### A — De-duplicate debug-channel alerts (`utils/debugLogger.ts`)
- `sendTelegramDebugMessage` suppresses identical-signature alerts within a window. Signature = alert text with digits stripped, so per-user / per-count / per-timestamp variants collapse to one key.
- Console logging is untouched — only the Telegram send is throttled. The next alert after the window prefixes `(N similar suppressed in last Xm)`.
- Window: `DEBUG_ALERT_DEDUP_WINDOW_SECONDS`, default 300s.

### B1 — Downgrade expected rate-limit aborts (`entities/WhatsAppSession.ts`)
- In `handleWhatsAppAPIErrors`, the retry-exhausted abort for `131056` / `131048` now logs via `logWarning` (⚠️) instead of `logError` (❌). Genuine transients (`2, 4, 80007, 130429`) stay at error severity. Retry logic unchanged.

### B2 — Per-recipient send serialization (`entities/WhatsAppSession.ts`)
- New `withRecipientLock` promise-chain mutex serializes sends per `chatId`, so overlapping flows (notification run, manual command, re-engagement sweep) can't saturate one number and trigger `131056` at the root.
- `sendWhatsAppMessage` / `sendWhatsAppTemplate` split into a public wrapper (acquires the lock) and an `*Inner` worker; the retry path re-enters the inner so the lock is held across backoff without a re-acquire deadlock.
- Orthogonal to the global `WHATSAPP_API_SENDING_CONCURRENCY` cap (which bounds total throughput, not per-recipient concurrency). Single-instance deployment assumed.

## Tests
- New: `tests/48.debugLogger.dedup.test.ts`, `tests/49.whatsappRateLimitHandling.test.ts`.
- `tests/18` mock updated for the new `logWarning` export.
- `tests/14` resume test confirms the lock does not deadlock retries.
- Full suite green (762 tests); build + lint clean via pre-push hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)