### PR TITLE
fix(notifications): keep runs alive through JORFSearch and WhatsApp faults

### DIFF
--- a/apps/whatsAppApp.ts
+++ b/apps/whatsAppApp.ts
@@ -4,6 +4,8 @@ import express from "express";
 
 import { WhatsAppAPI } from "whatsapp-api-js/middleware/express";
 import { PostData, ServerMessage } from "whatsapp-api-js/types";
+import type { OnMessageArgs } from "whatsapp-api-js/emitters";
+import { WhatsAppAPIError } from "whatsapp-api-js/errors";
 
 import { mongodbConnect, mongodbDisconnect } from "../db.ts";
 import umami from "../utils/umami.ts";
@@ -13,10 +15,15 @@ import {
   WhatsAppSession
 } from "../entities/WhatsAppSession.ts";
 import { startDailyNotificationJobs } from "../notifications/notificationScheduler.ts";
-import { logError, sendTelegramDebugMessage } from "../utils/debugLogger.ts";
+import {
+  logError,
+  logWarning,
+  sendTelegramDebugMessage
+} from "../utils/debugLogger.ts";
 import { handleIncomingMessage } from "../utils/messageWorkflow.ts";
 import { getCachedStats } from "../commands/stats.ts";
 import { createTtlDedup } from "../utils/webhookDedup.ts";
+import { textFromMessage } from "../utils/whatsAppMessageText.ts";
 
 const MAX_AGE_SEC = 5 * 60;
 const DUPLICATE_MESSAGE_TTL_MS = MAX_AGE_SEC * 1000;
@@ -212,7 +219,13 @@ await (async function () {
             return;
           }
         }
-        res.sendStatus(500);
+        // Meta redelivers on any non-2xx. Reply with the status the library
+        // attached to the error (401 on a bad signature, 400 on a malformed
+        // payload) so a permanently unprocessable delivery is not retried on a
+        // schedule; anything unclassified keeps the retryable 500.
+        res.sendStatus(
+          error instanceof WhatsAppAPIError ? error.httpStatus : 500
+        );
         await logError("WhatsApp", "Webhook processing failed", error);
       }
     });
@@ -288,9 +301,30 @@ await (async function () {
       }
     });
 
-    whatsAppAPI.on.message = async ({ phoneID, from, message }) => {
+    whatsAppAPI.on.message = async (args) => {
+      try {
+        await handleInboundMessage(whatsAppAPI, args);
+      } catch (error) {
+        // Never let a handler fault escape into `whatsAppAPI.post()`: it would
+        // turn the webhook reply into a 500 and Meta would redeliver the same
+        // payload on a schedule, replaying the same fault.
+        await logError("WhatsApp", "Error handling inbound message", error);
+      }
+    };
+
+    const handleInboundMessage = async (
+      api: WhatsAppAPI,
+      { phoneID, from, message }: OnMessageArgs
+    ): Promise<void> => {
       // Filter out events from the bot itself
       if (from === WHATSAPP_PHONE_ID) return;
+
+      // A "messages" change carrying an empty `messages` array reaches the
+      // emitter with no message at all, despite the non-optional type.
+      if ((message as ServerMessage | undefined) == null) {
+        await logWarning("WhatsApp", "Received message event with no message");
+        return;
+      }
 
       // Filter out non-text messages
       const msgText = textFromMessage(message);
@@ -325,12 +359,12 @@ await (async function () {
 
       try {
         // Mark as read in parallel (don't await)
-        void whatsAppAPI.markAsRead(phoneID, message.id);
+        void api.markAsRead(phoneID, message.id);
 
         const messageSentDate = new Date(messageTimeStampSeconds * 1000);
 
         const WHSession = new WhatsAppSession(
-          whatsAppAPI,
+          api,
           phoneID,
           from,
           "fr",
@@ -342,7 +376,6 @@ await (async function () {
       } catch (error) {
         await logError("WhatsApp", "Error processing inbound message", error);
       }
-      return;
     };
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -383,45 +416,6 @@ await (async function () {
     await logError("WhatsApp", "Failed to start app", error);
   }
 })();
-
-/**
- * Pick a printable fragment from any WhatsApp inbound message.
- * Returns `null` when there is nothing reasonably textual.
- */
-export function textFromMessage(msg: ServerMessage): string | null {
-  switch (msg.type) {
-    //  Plain text
-    case "text":
-      return msg.text.body;
-
-    // Quick-reply buttons
-    case "button":
-      return msg.button.text;
-
-    //  Interactive replies (List, Reply-button, Flow)  */
-    case "interactive":
-      switch (msg.interactive.type) {
-        case "list_reply":
-          return msg.interactive.list_reply.title;
-        case "button_reply":
-          return msg.interactive.button_reply.title;
-        /*
-      case "nfm_reply": // Flow submission
-        return (
-          msg.interactive.nfm_reply.body ??
-          msg.interactive.nfm_reply.response_json ??
-          null);
-        */
-      }
-      return null;
-
-    /*  Catch-all for anything the API marks
-         as unsupported or future types  */
-    default:
-      void logError("WhatsApp", `Unsupported message type: ${msg.type}`);
-      return null;
-  }
-}
 
 // Define an interface for the potential message-containing object
 interface WhatsAppValueObject {

--- a/commands/triggerPendingNotifications.ts
+++ b/commands/triggerPendingNotifications.ts
@@ -102,7 +102,7 @@ export const triggerPendingNotifications = async (
       itemsOut.values()
     ).flat();
 
-    await notifyAllFollows(
+    const failedHandlers = await notifyAllFollows(
       candidateJORFSearchItems,
       candidateJORFPublications,
       [session.messageApp],
@@ -113,6 +113,15 @@ export const triggerPendingNotifications = async (
       [session.user._id],
       true
     );
+    if (failedHandlers.length > 0) {
+      // Keep the pending queue so the user can retrigger; clearing it here would
+      // drop the notifications the failed handlers never delivered.
+      await logError(
+        session.messageApp,
+        `Pending notifications kept for user ${session.user._id.toString()}: handlers failed (${failedHandlers.join(", ")})`
+      );
+      return;
+    }
 
     await User.updateOne(
       { _id: session.user._id },

--- a/notifications/alertStringNotifications.ts
+++ b/notifications/alertStringNotifications.ts
@@ -36,7 +36,14 @@ export async function notifyAlertStringUpdates(
   // the 24h-window decision can't drift as the (slow) run progresses.
   windowNow: Date,
   userIds?: Types.ObjectId[],
-  forceWHMessages = false
+  forceWHMessages = false,
+  // Newest instant this run is known to have complete JORFSearch coverage for.
+  // Equal to `windowNow` on a healthy run; clamped to just before the oldest
+  // unfetched day when the range had a gap, so a follow's `lastUpdate` never
+  // steps over a day whose records were never seen. Kept apart from
+  // `windowNow`: rewinding the 24h-window clock would let WhatsApp sends slip
+  // outside their re-engagement window.
+  coverageCursor: Date = windowNow
 ) {
   if (metaRecords.length === 0) return;
 
@@ -213,8 +220,8 @@ export async function notifyAlertStringUpdates(
         const res = await User.updateOne(
           { _id: task.userId },
           {
-            $set: {
-              "followedMeta.$[elem].lastUpdate": now
+            $max: {
+              "followedMeta.$[elem].lastUpdate": coverageCursor
             }
           },
           {
@@ -225,7 +232,7 @@ export async function notifyAlertStringUpdates(
             ]
           }
         );
-        if (res.modifiedCount === 0) {
+        if (res.matchedCount === 0) {
           await logError(
             task.userInfo.messageApp,
             `No lastUpdate updated for user ${task.userId.toString()} after storing pending text update notifications (WH reengagement)`
@@ -245,10 +252,15 @@ export async function notifyAlertStringUpdates(
       if (!messageSent) return;
 
       const res = await User.updateOne(
-        { _id: task.userId },
         {
-          $set: {
-            "followedMeta.$[elem].lastUpdate": now
+          _id: task.userId,
+          "followedMeta.alertString": {
+            $in: [...task.updatedRecordsMap.keys()]
+          }
+        },
+        {
+          $max: {
+            "followedMeta.$[elem].lastUpdate": coverageCursor
           }
         },
         {
@@ -259,7 +271,7 @@ export async function notifyAlertStringUpdates(
           ]
         }
       );
-      if (res.modifiedCount === 0) {
+      if (res.matchedCount === 0) {
         await logError(
           task.userInfo.messageApp,
           `No lastUpdate updated for user ${task.userId.toString()} after sending text update notifications`

--- a/notifications/functionTagNotifications.ts
+++ b/notifications/functionTagNotifications.ts
@@ -92,7 +92,14 @@ export async function notifyFunctionTagsUpdates(
   // the 24h-window decision can't drift as the (slow) run progresses.
   windowNow: Date,
   userIds?: Types.ObjectId[],
-  forceWHMessages = false
+  forceWHMessages = false,
+  // Newest instant this run is known to have complete JORFSearch coverage for.
+  // Equal to `windowNow` on a healthy run; clamped to just before the oldest
+  // unfetched day when the range had a gap, so a follow's `lastUpdate` never
+  // steps over a day whose records were never seen. Kept apart from
+  // `windowNow`: rewinding the 24h-window clock would let WhatsApp sends slip
+  // outside their re-engagement window.
+  coverageCursor: Date = windowNow
 ) {
   if (updatedRecords.length === 0) return;
 
@@ -289,7 +296,7 @@ export async function notifyFunctionTagsUpdates(
             _id: task.userId,
             "followedFunctions.functionTag": { $in: updatedTags }
           },
-          { $set: { "followedFunctions.$[elem].lastUpdate": now } },
+          { $max: { "followedFunctions.$[elem].lastUpdate": coverageCursor } },
           {
             arrayFilters: [
               {
@@ -298,7 +305,7 @@ export async function notifyFunctionTagsUpdates(
             ]
           }
         );
-        if (res.modifiedCount === 0) {
+        if (res.matchedCount === 0) {
           await logError(
             task.userInfo.messageApp,
             `No lastUpdate updated for user ${task.userId.toString()} after storing pending tag update notifications (WH reengagement)`
@@ -324,7 +331,7 @@ export async function notifyFunctionTagsUpdates(
             $in: [...task.updatedRecordsMap.keys()]
           }
         },
-        { $set: { "followedFunctions.$[elem].lastUpdate": now } },
+        { $max: { "followedFunctions.$[elem].lastUpdate": coverageCursor } },
         {
           arrayFilters: [
             {
@@ -333,7 +340,7 @@ export async function notifyFunctionTagsUpdates(
           ]
         }
       );
-      if (res.modifiedCount === 0) {
+      if (res.matchedCount === 0) {
         await logError(
           task.userInfo.messageApp,
           `No lastUpdate updated for user ${task.userId.toString()} after sending tag update notifications`

--- a/notifications/nameNotifications.ts
+++ b/notifications/nameNotifications.ts
@@ -35,7 +35,7 @@ export async function updateFollowedNamesToFollowedPeople(
   updatedRecordsMapKeys: string[],
   peopleIdByFollowedNameMap: Map<string, Types.ObjectId>,
   userFollowingNames: IUser[],
-  now: Date,
+  coverageCursor: Date,
   errorLogSuffix: string,
   messageApp: MessageApp,
   source: "direct" | "pending"
@@ -74,7 +74,7 @@ export async function updateFollowedNamesToFollowedPeople(
         followedPeople: {
           $each: newFollowsIdUnique.map((id) => ({
             peopleId: id,
-            lastUpdate: now
+            lastUpdate: coverageCursor
           }))
         }
       }
@@ -96,7 +96,14 @@ export async function notifyNameMentionUpdates(
   // the 24h-window decision can't drift as the (slow) run progresses.
   windowNow: Date,
   userIds?: Types.ObjectId[],
-  forceWHMessages = false
+  forceWHMessages = false,
+  // Newest instant this run is known to have complete JORFSearch coverage for.
+  // Equal to `windowNow` on a healthy run; clamped to just before the oldest
+  // unfetched day when the range had a gap, so a follow's `lastUpdate` never
+  // steps over a day whose records were never seen. Kept apart from
+  // `windowNow`: rewinding the 24h-window clock would let WhatsApp sends slip
+  // outside their re-engagement window.
+  coverageCursor: Date = windowNow
 ) {
   let dbFilters: QueryFilter<IUser> = {
     "followedNames.0": { $exists: true },
@@ -290,7 +297,7 @@ export async function notifyNameMentionUpdates(
         [...task.updatedRecordsMap.keys()],
         peopleIdByFollowedNameMap,
         userFollowingNames,
-        now,
+        coverageCursor,
         "after storing pending name update notifications",
         task.userInfo.messageApp,
         "pending"
@@ -313,7 +320,7 @@ export async function notifyNameMentionUpdates(
         [...task.updatedRecordsMap.keys()],
         peopleIdByFollowedNameMap,
         userFollowingNames,
-        now,
+        coverageCursor,
         "after sending name update notifications",
         task.userInfo.messageApp,
         "direct"

--- a/notifications/notificationScheduler.ts
+++ b/notifications/notificationScheduler.ts
@@ -1,6 +1,9 @@
 import "dotenv/config";
 import { MessageApp } from "../types.ts";
-import { runNotificationProcess } from "./runNotificationProcess.ts";
+import {
+  logNotificationOutcome,
+  runNotificationProcess
+} from "./runNotificationProcess.ts";
 import { ExternalMessageOptions } from "../entities/Session.ts";
 import { logError, logWarning } from "../utils/debugLogger.ts";
 import { dateToString, formatDuration } from "../utils/date.utils.ts";
@@ -9,6 +12,47 @@ import { WHATSAPP_SHIFT_STEP_MINS } from "../entities/WhatsAppSession.ts";
 interface DailyTime {
   hour: number;
   minute: number;
+}
+
+// Used when the next occurrence cannot be computed: losing the reschedule would
+// end notifications for the whole process until someone restarts it, so the
+// loop retries on this cadence instead of unwinding.
+const RESCHEDULE_RETRY_DELAY_MS = 60 * 60 * 1000;
+
+// A run that never settles would take the whole schedule with it, because the
+// next occurrence is only armed once the current one finishes. Well above any
+// legitimate run (the slow-run warning trips at 5 minutes) and well under the
+// daily cadence, so it only fires on a genuine hang.
+const RUN_WATCHDOG_MS = 6 * 60 * 60 * 1000;
+
+class RunWatchdogError extends Error {}
+
+/**
+ * Rejects if `task` outstays `timeoutMs`. The task itself keeps running: it
+ * cannot be cancelled, so the caller reschedules around it and lets the
+ * still-running guard report the cycles it overlaps.
+ */
+async function withWatchdog<T>(
+  task: Promise<T>,
+  timeoutMs: number
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      task,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new RunWatchdogError(
+              `Notification process still unfinished after ${formatDuration(timeoutMs)}`
+            )
+          );
+        }, timeoutMs);
+      })
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 let lastNotificationDayString: string | null = null;
@@ -136,13 +180,38 @@ export function startDailyNotificationJobs(
   const parsedTime = parseDailyTime(configuredTime);
 
   let running = false;
+  // Only the most recently armed timer may act. The watchdog can leave a hung
+  // run behind that still reschedules when it eventually settles, and without
+  // this the two chains would both keep firing forever.
+  let scheduleToken = 0;
 
   const scheduleNextRun = () => {
-    const nextRun = computeNextOccurrence(parsedTime, messageApps);
+    const token = ++scheduleToken;
+
+    let nextRun: Date;
+    try {
+      nextRun = computeNextOccurrence(parsedTime, messageApps);
+    } catch (error) {
+      void Promise.all(
+        messageApps.map((app) =>
+          logError(
+            app,
+            `Could not compute the next notification time; retrying in ${formatDuration(RESCHEDULE_RETRY_DELAY_MS)}.`,
+            error
+          )
+        )
+      );
+      setTimeout(() => {
+        if (token !== scheduleToken) return;
+        scheduleNextRun();
+      }, RESCHEDULE_RETRY_DELAY_MS);
+      return;
+    }
     const delay = nextRun.getTime() - Date.now();
 
     setTimeout(() => {
       void (async () => {
+        if (token !== scheduleToken) return;
         if (running) {
           await Promise.all(
             messageApps.map((app) =>
@@ -152,22 +221,43 @@ export function startDailyNotificationJobs(
               )
             )
           );
+          // Reported like any other cycle: one event per app per fired
+          // schedule is what makes a missing event mean "the process was down"
+          // rather than "something swallowed it".
+          await logNotificationOutcome(messageApps, "skipped", 0, [
+            "previous run still in progress"
+          ]);
           scheduleNextRun();
           return;
         }
 
         running = true;
+        const runPromise = runNotificationProcess(messageApps, messageOptions);
+        // Bound to the run itself rather than to the wait below, so a run the
+        // watchdog gave up on still releases the flag if it later settles.
+        // Until it does, the still-running guard reports every cycle it eats
+        // instead of the schedule going quiet.
+        void runPromise
+          .catch(() => undefined)
+          .finally(() => {
+            running = false;
+            lastNotificationDayString = dateToString(new Date(), "YMD");
+          });
+
         try {
-          await runNotificationProcess(messageApps, messageOptions);
+          await withWatchdog(runPromise, RUN_WATCHDOG_MS);
         } catch (error) {
           await Promise.all(
             messageApps.map((app) =>
               logError(app, `${app}: error during notification process`, error)
             )
           );
+          if (error instanceof RunWatchdogError) {
+            await logNotificationOutcome(messageApps, "failed", 0, [
+              "run did not finish within the watchdog"
+            ]);
+          }
         } finally {
-          running = false;
-          lastNotificationDayString = dateToString(new Date(), "YMD");
           scheduleNextRun();
         }
       })();

--- a/notifications/organisationNotifications.ts
+++ b/notifications/organisationNotifications.ts
@@ -73,7 +73,14 @@ export async function notifyOrganisationsUpdates(
   // the 24h-window decision can't drift as the (slow) run progresses.
   windowNow: Date,
   userIds?: Types.ObjectId[],
-  forceWHMessages = false
+  forceWHMessages = false,
+  // Newest instant this run is known to have complete JORFSearch coverage for.
+  // Equal to `windowNow` on a healthy run; clamped to just before the oldest
+  // unfetched day when the range had a gap, so a follow's `lastUpdate` never
+  // steps over a day whose records were never seen. Kept apart from
+  // `windowNow`: rewinding the 24h-window clock would let WhatsApp sends slip
+  // outside their re-engagement window.
+  coverageCursor: Date = windowNow
 ) {
   const updatedOrgsWikidataIdSet = new Set<WikidataId>(
     allUpdatedRecords
@@ -294,7 +301,7 @@ export async function notifyOrganisationsUpdates(
               $in: updatedWikidataIds
             }
           },
-          { $set: { "followedOrganisations.$[elem].lastUpdate": now } },
+          { $max: { "followedOrganisations.$[elem].lastUpdate": coverageCursor } },
           {
             arrayFilters: [
               {
@@ -305,7 +312,7 @@ export async function notifyOrganisationsUpdates(
             ]
           }
         );
-        if (res.modifiedCount === 0) {
+        if (res.matchedCount === 0) {
           await logError(
             task.userInfo.messageApp,
             `No lastUpdate updated for user ${task.userId.toString()} after storing pending organisation update notifications (WH reengagement)`
@@ -332,7 +339,9 @@ export async function notifyOrganisationsUpdates(
             $in: [...task.updatedRecordsMap.keys()]
           }
         },
-        { $set: { "followedOrganisations.$[elem].lastUpdate": now } },
+        {
+          $max: { "followedOrganisations.$[elem].lastUpdate": coverageCursor }
+        },
         {
           arrayFilters: [
             {
@@ -343,7 +352,7 @@ export async function notifyOrganisationsUpdates(
           ]
         }
       );
-      if (res.modifiedCount === 0) {
+      if (res.matchedCount === 0) {
         await logError(
           task.userInfo.messageApp,
           `No lastUpdate updated for user ${task.userId.toString()} after sending organisation update notifications`

--- a/notifications/peopleNotifications.ts
+++ b/notifications/peopleNotifications.ts
@@ -51,7 +51,14 @@ export async function notifyPeopleUpdates(
   // the 24h-window decision can't drift as the (slow) run progresses.
   windowNow: Date,
   userIds?: Types.ObjectId[],
-  forceWHMessages = false
+  forceWHMessages = false,
+  // Newest instant this run is known to have complete JORFSearch coverage for.
+  // Equal to `windowNow` on a healthy run; clamped to just before the oldest
+  // unfetched day when the range had a gap, so a follow's `lastUpdate` never
+  // steps over a day whose records were never seen. Kept apart from
+  // `windowNow`: rewinding the 24h-window clock would let WhatsApp sends slip
+  // outside their re-engagement window.
+  coverageCursor: Date = windowNow
 ) {
   if (updatedRecords.length === 0) return;
 
@@ -297,7 +304,7 @@ export async function notifyPeopleUpdates(
             $in: updatedRecordsPeopleId
           }
         },
-        { $set: { "followedPeople.$[elem].lastUpdate": now } },
+        { $max: { "followedPeople.$[elem].lastUpdate": coverageCursor } },
         {
           arrayFilters: [
             {
@@ -306,7 +313,7 @@ export async function notifyPeopleUpdates(
           ]
         }
       );
-      if (res.modifiedCount === 0) {
+      if (res.matchedCount === 0) {
         await logError(
           task.userInfo.messageApp,
           `No lastUpdate updated for user ${task.userId.toString()} after storing pending people update notifications (WH reengagement)`
@@ -337,7 +344,7 @@ export async function notifyPeopleUpdates(
           $in: updatedRecordsPeopleId
         }
       },
-      { $set: { "followedPeople.$[elem].lastUpdate": now } },
+      { $max: { "followedPeople.$[elem].lastUpdate": coverageCursor } },
       {
         arrayFilters: [
           {
@@ -346,7 +353,7 @@ export async function notifyPeopleUpdates(
         ]
       }
     );
-    if (res.modifiedCount === 0) {
+    if (res.matchedCount === 0) {
       await logError(
         task.userInfo.messageApp,
         `No lastUpdate updated for user ${task.userId.toString()} after sending people update notifications`

--- a/notifications/runNotificationProcess.ts
+++ b/notifications/runNotificationProcess.ts
@@ -59,7 +59,7 @@ async function fetchRange<T>(
   fetch: () => Promise<JORFRangeResult<T>>,
   targetApps: MessageApp[],
   windowNow: Date
-): Promise<{ items: T[]; coverageCursor: Date }> {
+): Promise<{ items: T[]; coverageCursor: Date; degraded: boolean }> {
   let range: JORFRangeResult<T>;
   try {
     range = await fetch();
@@ -69,11 +69,11 @@ async function fetchRange<T>(
       `Could not fetch JORF ${label}: the matching notifications are skipped for this run.`,
       error
     );
-    return { items: [], coverageCursor: windowNow };
+    return { items: [], coverageCursor: windowNow, degraded: true };
   }
 
   if (range.failedDates.length === 0) {
-    return { items: range.items, coverageCursor: windowNow };
+    return { items: range.items, coverageCursor: windowNow, degraded: false };
   }
 
   const allDaysFailed = range.failedDates.length === range.requestedDays;
@@ -88,7 +88,8 @@ async function fetchRange<T>(
   // handlers no-op on an empty list either way.
   return {
     items: allDaysFailed ? [] : range.items,
-    coverageCursor: coverageCursorFor(windowNow, range.failedDates)
+    coverageCursor: coverageCursorFor(windowNow, range.failedDates),
+    degraded: true
   };
 }
 
@@ -96,12 +97,64 @@ async function fetchRange<T>(
 // in real time at each send, so a slow run no longer risks 131047 errors.
 const NOTIFICATION_DURATION_BEFORE_WARNING_MS = 5 * 60 * 1000; // 5 minutes
 
+/**
+ * How a scheduled cycle ended.
+ *
+ * - `completed`: every source fetched and every handler ran.
+ * - `degraded`: the run delivered what it could, but something was skipped.
+ * - `failed`: the run aborted on an unexpected error.
+ * - `skipped`: the cycle did no work (a client was missing, or the previous run
+ *   was still going).
+ */
+export type NotificationOutcome =
+  "completed" | "degraded" | "failed" | "skipped";
+
+/**
+ * Records the end of one scheduled cycle, once per app.
+ *
+ * Every cycle emits exactly one event per app whatever happens to it, so a
+ * missing event means the process was not running: no other reading is
+ * possible. That only holds if the send itself is verified, hence
+ * `logAsyncVerified` and the alert when it fails.
+ */
+export async function logNotificationOutcome(
+  targetApps: MessageApp[],
+  outcome: NotificationOutcome,
+  duration_s: number,
+  degradations: string[] = []
+): Promise<void> {
+  const unreported: MessageApp[] = [];
+  for (const messageApp of targetApps) {
+    const reported = await umami.logAsyncVerified({
+      event: "/notification-process-completed",
+      messageApp,
+      hasAccount: true,
+      payload: {
+        duration_s,
+        outcome,
+        degraded_steps: degradations.join(" | ")
+      }
+    });
+    if (!reported) unreported.push(messageApp);
+  }
+
+  if (unreported.length > 0) {
+    await logErrorForApps(
+      unreported,
+      `Umami did not record the end of the notification process (outcome: ${outcome}). The run itself is unaffected, but its telemetry is missing.`
+    );
+  }
+}
+
 export async function runNotificationProcess(
   targetApps: MessageApp[],
   messageAppsOptions: ExternalMessageOptions
 ): Promise<void> {
   const start = new Date();
   console.log("Notification started.");
+  // Whatever happens below, the `finally` reports one outcome per app.
+  let outcome: NotificationOutcome = "skipped";
+  const degradations: string[] = [];
   try {
     if (
       targetApps.some((a) => a === "Matrix") &&
@@ -150,7 +203,18 @@ export async function runNotificationProcess(
     if (mongoose.connection.readyState.valueOf() != 1) await mongodbConnect();
 
     if (targetApps.includes("Telegram")) {
-      await refreshTelegramBlockedUsers(messageAppsOptions.telegramBotToken);
+      try {
+        await refreshTelegramBlockedUsers(messageAppsOptions.telegramBotToken);
+      } catch (error) {
+        // Only costs us the chance to skip users who already blocked the bot:
+        // their sends fail individually and are handled per user.
+        degradations.push("Telegram blocked-user refresh");
+        await logError(
+          "Telegram",
+          "Could not refresh the Telegram blocked-user list; sends to blocked users will fail individually",
+          error
+        );
+      }
     }
 
     // Number of days to go back: 0 means we just fetch today's info
@@ -216,7 +280,11 @@ export async function runNotificationProcess(
         meta: metaRecords.coverageCursor
       }
     );
+    if (records.degraded) degradations.push("JORF records fetch");
+    if (metaRecords.degraded) degradations.push("JORF meta fetch");
+
     if (failedHandlers.length > 0) {
+      degradations.push(...failedHandlers.map((h) => `${h} handler`));
       await logErrorForApps(
         targetApps,
         `Notification handlers failed and were skipped: ${failedHandlers.join(", ")}. Other handlers ran normally.`
@@ -229,6 +297,7 @@ export async function runNotificationProcess(
       try {
         await runReengagementReminderSweep(messageAppsOptions);
       } catch (error) {
+        degradations.push("re-engagement reminder sweep");
         await logError(
           "WhatsApp",
           "Error running the re-engagement reminder sweep",
@@ -237,38 +306,32 @@ export async function runNotificationProcess(
       }
     }
 
-    const duration_s = Math.ceil(
-      (new Date().getTime() - start.getTime()) / 1000
+    outcome = degradations.length > 0 ? "degraded" : "completed";
+  } catch (err) {
+    outcome = "failed";
+    await logErrorForApps(
+      targetApps,
+      "Error running notification process: ",
+      err
+    );
+  } finally {
+    const delay = new Date().getTime() - start.getTime();
+    await logNotificationOutcome(
+      targetApps,
+      outcome,
+      Math.ceil(delay / 1000),
+      degradations
     );
 
-    for (const appType of targetApps) {
-      await umami.logAsync({
-        event: "/notification-process-completed",
-        messageApp: appType,
-        hasAccount: true,
-        payload: { duration_s }
-      });
+    if (delay > NOTIFICATION_DURATION_BEFORE_WARNING_MS) {
+      await logErrorForApps(
+        targetApps,
+        `Notification process took too long: ${formatDuration(delay)}.`
+      );
     }
-
-    const end = new Date();
-
-    const delay = end.getTime() - start.getTime();
-    if (
-      end.getTime() - start.getTime() >
-      NOTIFICATION_DURATION_BEFORE_WARNING_MS
-    ) {
-      for (const appType of targetApps) {
-        await logError(
-          appType,
-          `Notification process took too long: ${formatDuration(delay)}.`
-        );
-      }
-    }
-    console.log(`Notification ended: took ${formatDuration(delay)}.`);
-  } catch (err) {
-    for (const appType of targetApps) {
-      await logError(appType, "Error running notification process: ", err);
-    }
+    console.log(
+      `Notification ended (${outcome}): took ${formatDuration(delay)}.`
+    );
   }
 }
 

--- a/notifications/runNotificationProcess.ts
+++ b/notifications/runNotificationProcess.ts
@@ -281,6 +281,10 @@ export async function notifyAllFollows(
   // same instant, so a user can't be in-window for handler 1 and expired by
   // handler 5 just because the run is slow.
   windowNow: Date,
+  // Restricts every handler to these users. A caller notifying one user on
+  // demand must reach all five handlers, otherwise the unscoped ones deliver
+  // that user's records to everyone else who happens to follow the same name or
+  // alert string, and move their cursors too.
   userIds?: Types.ObjectId[],
   forceWHMessages = false,
   // How far each source is known to be complete. The default suits callers
@@ -342,10 +346,8 @@ export async function notifyAllFollows(
             targetApps,
             messageAppsOptions,
             windowNow,
-            // `userIds` / `forceWHMessages` are deliberately not forwarded here:
-            // this handler has always run unscoped and unforced.
-            undefined,
-            false,
+            userIds,
+            forceWHMessages,
             coverageCursors.records
           )
       }
@@ -361,9 +363,8 @@ export async function notifyAllFollows(
           targetApps,
           messageAppsOptions,
           windowNow,
-          // Unscoped and unforced, as this handler has always been called.
-          undefined,
-          false,
+          userIds,
+          forceWHMessages,
           coverageCursors.meta
         )
     });

--- a/notifications/runNotificationProcess.ts
+++ b/notifications/runNotificationProcess.ts
@@ -20,7 +20,7 @@ import {
   getJORFRecordsFromDate,
   JORFRangeResult
 } from "../utils/JORFSearch.utils.ts";
-import { formatDuration } from "../utils/date.utils.ts";
+import { formatDuration, JORFtoDate } from "../utils/date.utils.ts";
 
 /**
  * Runs one JORFSearch range fetch, downgrading every failure mode to an empty
@@ -32,11 +32,34 @@ import { formatDuration } from "../utils/date.utils.ts";
  * follow's `lastUpdate` forward on delivery and will not revisit the missed
  * days on their own.
  */
+/**
+ * Newest instant a range is known to cover completely.
+ *
+ * Coverage runs forward from a follow's stored `lastUpdate`, so it ends at the
+ * first day the range failed to fetch: everything from that day on is unknown,
+ * whether or not later days succeeded. Returns the last millisecond before that
+ * day starts, which keeps records dated that day above the cursor and therefore
+ * eligible on a later run. `JORFtoDate` and the handlers' own comparisons both
+ * place a YMD date at local midnight, so the two agree on the boundary.
+ */
+export function coverageCursorFor(
+  windowNow: Date,
+  failedDates: string[]
+): Date {
+  if (failedDates.length === 0) return windowNow;
+  // YMD sorts lexicographically in date order.
+  const oldestGap = failedDates.reduce((a, b) => (a < b ? a : b));
+  return new Date(
+    Math.min(windowNow.getTime(), JORFtoDate(oldestGap).getTime() - 1)
+  );
+}
+
 async function fetchRange<T>(
   label: string,
   fetch: () => Promise<JORFRangeResult<T>>,
-  targetApps: MessageApp[]
-): Promise<{ items: T[] }> {
+  targetApps: MessageApp[],
+  windowNow: Date
+): Promise<{ items: T[]; coverageCursor: Date }> {
   let range: JORFRangeResult<T>;
   try {
     range = await fetch();
@@ -46,22 +69,27 @@ async function fetchRange<T>(
       `Could not fetch JORF ${label}: the matching notifications are skipped for this run.`,
       error
     );
-    return { items: [] };
+    return { items: [], coverageCursor: windowNow };
   }
 
-  if (range.failedDates.length === 0) return { items: range.items };
+  if (range.failedDates.length === 0) {
+    return { items: range.items, coverageCursor: windowNow };
+  }
 
   const allDaysFailed = range.failedDates.length === range.requestedDays;
   await logErrorForApps(
     targetApps,
     allDaysFailed
       ? `JORFSearch is unreachable for ${label}: no day of the range could be fetched, the matching notifications are skipped for this run.`
-      : `JORFSearch returned no data for ${String(range.failedDates.length)}/${String(range.requestedDays)} day(s) of ${label} (${range.failedDates.join(", ")}). Notifications are sent for the days that were fetched; replay the missing days with NOTIFICATIONS_SHIFT_DAYS.`
+      : `JORFSearch returned no data for ${String(range.failedDates.length)}/${String(range.requestedDays)} day(s) of ${label} (${range.failedDates.join(", ")}). Notifications are sent for the days that were fetched, and follows are not advanced past ${range.failedDates.reduce((a, b) => (a < b ? a : b))} so the gap is picked up on a later run.`
   );
 
   // A fully failed range is indistinguishable from "nothing was published", and
   // handlers no-op on an empty list either way.
-  return { items: allDaysFailed ? [] : range.items };
+  return {
+    items: allDaysFailed ? [] : range.items,
+    coverageCursor: coverageCursorFor(windowNow, range.failedDates)
+  };
 }
 
 // Ops latency warning only: the WhatsApp send guard re-checks the 24h window
@@ -164,12 +192,14 @@ export async function runNotificationProcess(
     const records = await fetchRange(
       "records",
       () => getJORFRecordsFromDate(startDate, targetApps),
-      targetApps
+      targetApps,
+      start
     );
     const metaRecords = await fetchRange(
       "meta publications",
       () => getJORFMetaRecordsFromDate(startDate, targetApps),
-      targetApps
+      targetApps,
+      start
     );
 
     const failedHandlers = await notifyAllFollows(
@@ -178,7 +208,13 @@ export async function runNotificationProcess(
       targetApps,
       messageAppsOptions,
       // `start` is the process-start snapshot; reuse it as the single window clock.
-      start
+      start,
+      undefined,
+      false,
+      {
+        records: records.coverageCursor,
+        meta: metaRecords.coverageCursor
+      }
     );
     if (failedHandlers.length > 0) {
       await logErrorForApps(
@@ -246,7 +282,14 @@ export async function notifyAllFollows(
   // handler 5 just because the run is slow.
   windowNow: Date,
   userIds?: Types.ObjectId[],
-  forceWHMessages = false
+  forceWHMessages = false,
+  // How far each source is known to be complete. The default suits callers
+  // whose records come from explicit lookups rather than a day range, where
+  // coverage is total by construction.
+  coverageCursors: { records: Date; meta: Date } = {
+    records: windowNow,
+    meta: windowNow
+  }
 ): Promise<string[]> {
   const handlers: { name: string; run: () => Promise<void> }[] = [];
 
@@ -261,7 +304,8 @@ export async function notifyAllFollows(
             messageAppsOptions,
             windowNow,
             userIds,
-            forceWHMessages
+            forceWHMessages,
+            coverageCursors.records
           )
       },
       {
@@ -273,7 +317,8 @@ export async function notifyAllFollows(
             messageAppsOptions,
             windowNow,
             userIds,
-            forceWHMessages
+            forceWHMessages,
+            coverageCursors.records
           )
       },
       {
@@ -285,7 +330,8 @@ export async function notifyAllFollows(
             messageAppsOptions,
             windowNow,
             userIds,
-            forceWHMessages
+            forceWHMessages,
+            coverageCursors.records
           )
       },
       {
@@ -295,7 +341,12 @@ export async function notifyAllFollows(
             JORFAllRecordsFromDate,
             targetApps,
             messageAppsOptions,
-            windowNow
+            windowNow,
+            // `userIds` / `forceWHMessages` are deliberately not forwarded here:
+            // this handler has always run unscoped and unforced.
+            undefined,
+            false,
+            coverageCursors.records
           )
       }
     );
@@ -309,7 +360,11 @@ export async function notifyAllFollows(
           JORFMetaRecordsFromDate,
           targetApps,
           messageAppsOptions,
-          windowNow
+          windowNow,
+          // Unscoped and unforced, as this handler has always been called.
+          undefined,
+          false,
+          coverageCursors.meta
         )
     });
   }

--- a/notifications/runNotificationProcess.ts
+++ b/notifications/runNotificationProcess.ts
@@ -14,12 +14,55 @@ import mongoose, { Types } from "mongoose";
 
 import { ExternalMessageOptions } from "../entities/Session.ts";
 import { refreshTelegramBlockedUsers } from "../entities/TelegramSession.ts";
-import { logError } from "../utils/debugLogger.ts";
+import { logError, logErrorForApps } from "../utils/debugLogger.ts";
 import {
   getJORFMetaRecordsFromDate,
-  getJORFRecordsFromDate
+  getJORFRecordsFromDate,
+  JORFRangeResult
 } from "../utils/JORFSearch.utils.ts";
 import { formatDuration } from "../utils/date.utils.ts";
+
+/**
+ * Runs one JORFSearch range fetch, downgrading every failure mode to an empty
+ * item list so the rest of the run can proceed.
+ *
+ * A partial range still yields its items: serving the users whose follows were
+ * published on a reachable day beats serving nobody. The gap is reported so it
+ * can be replayed with NOTIFICATIONS_SHIFT_DAYS, because handlers move each
+ * follow's `lastUpdate` forward on delivery and will not revisit the missed
+ * days on their own.
+ */
+async function fetchRange<T>(
+  label: string,
+  fetch: () => Promise<JORFRangeResult<T>>,
+  targetApps: MessageApp[]
+): Promise<{ items: T[] }> {
+  let range: JORFRangeResult<T>;
+  try {
+    range = await fetch();
+  } catch (error) {
+    await logErrorForApps(
+      targetApps,
+      `Could not fetch JORF ${label}: the matching notifications are skipped for this run.`,
+      error
+    );
+    return { items: [] };
+  }
+
+  if (range.failedDates.length === 0) return { items: range.items };
+
+  const allDaysFailed = range.failedDates.length === range.requestedDays;
+  await logErrorForApps(
+    targetApps,
+    allDaysFailed
+      ? `JORFSearch is unreachable for ${label}: no day of the range could be fetched, the matching notifications are skipped for this run.`
+      : `JORFSearch returned no data for ${String(range.failedDates.length)}/${String(range.requestedDays)} day(s) of ${label} (${range.failedDates.join(", ")}). Notifications are sent for the days that were fetched; replay the missing days with NOTIFICATIONS_SHIFT_DAYS.`
+  );
+
+  // A fully failed range is indistinguishable from "nothing was published", and
+  // handlers no-op on an empty list either way.
+  return { items: allDaysFailed ? [] : range.items };
+}
 
 // Ops latency warning only: the WhatsApp send guard re-checks the 24h window
 // in real time at each send, so a slow run no longer risks 131047 errors.
@@ -116,27 +159,46 @@ export async function runNotificationProcess(
     );
     startDate.setHours(0, 0, 0, 0);
 
-    const JORFAllRecordsFromDate = await getJORFRecordsFromDate(
-      startDate,
+    // Each source is fetched independently: one being unreachable must not cost
+    // users the notifications the other one can still deliver.
+    const records = await fetchRange(
+      "records",
+      () => getJORFRecordsFromDate(startDate, targetApps),
       targetApps
     );
-    const JORFMetaRecordsFromDate = await getJORFMetaRecordsFromDate(
-      startDate,
+    const metaRecords = await fetchRange(
+      "meta publications",
+      () => getJORFMetaRecordsFromDate(startDate, targetApps),
       targetApps
     );
 
-    await notifyAllFollows(
-      JORFAllRecordsFromDate,
-      JORFMetaRecordsFromDate,
+    const failedHandlers = await notifyAllFollows(
+      records.items,
+      metaRecords.items,
       targetApps,
       messageAppsOptions,
       // `start` is the process-start snapshot; reuse it as the single window clock.
       start
     );
+    if (failedHandlers.length > 0) {
+      await logErrorForApps(
+        targetApps,
+        `Notification handlers failed and were skipped: ${failedHandlers.join(", ")}. Other handlers ran normally.`
+      );
+    }
 
     // Weekly reminder for WhatsApp users sitting on pending notifications.
+    // Independent of JORF: it must still run after a fetch or handler failure.
     if (targetApps.includes("WhatsApp")) {
-      await runReengagementReminderSweep(messageAppsOptions);
+      try {
+        await runReengagementReminderSweep(messageAppsOptions);
+      } catch (error) {
+        await logError(
+          "WhatsApp",
+          "Error running the re-engagement reminder sweep",
+          error
+        );
+      }
     }
 
     const duration_s = Math.ceil(
@@ -185,49 +247,88 @@ export async function notifyAllFollows(
   windowNow: Date,
   userIds?: Types.ObjectId[],
   forceWHMessages = false
-) {
+): Promise<string[]> {
+  const handlers: { name: string; run: () => Promise<void> }[] = [];
+
   if (JORFAllRecordsFromDate.length > 0) {
-    await notifyFunctionTagsUpdates(
-      JORFAllRecordsFromDate,
-      targetApps,
-      messageAppsOptions,
-      windowNow,
-      userIds,
-      forceWHMessages
-    );
-
-    await notifyOrganisationsUpdates(
-      JORFAllRecordsFromDate,
-      targetApps,
-      messageAppsOptions,
-      windowNow,
-      userIds,
-      forceWHMessages
-    );
-
-    await notifyPeopleUpdates(
-      JORFAllRecordsFromDate,
-      targetApps,
-      messageAppsOptions,
-      windowNow,
-      userIds,
-      forceWHMessages
-    );
-
-    await notifyNameMentionUpdates(
-      JORFAllRecordsFromDate,
-      targetApps,
-      messageAppsOptions,
-      windowNow
+    handlers.push(
+      {
+        name: "function tags",
+        run: () =>
+          notifyFunctionTagsUpdates(
+            JORFAllRecordsFromDate,
+            targetApps,
+            messageAppsOptions,
+            windowNow,
+            userIds,
+            forceWHMessages
+          )
+      },
+      {
+        name: "organisations",
+        run: () =>
+          notifyOrganisationsUpdates(
+            JORFAllRecordsFromDate,
+            targetApps,
+            messageAppsOptions,
+            windowNow,
+            userIds,
+            forceWHMessages
+          )
+      },
+      {
+        name: "people",
+        run: () =>
+          notifyPeopleUpdates(
+            JORFAllRecordsFromDate,
+            targetApps,
+            messageAppsOptions,
+            windowNow,
+            userIds,
+            forceWHMessages
+          )
+      },
+      {
+        name: "name mentions",
+        run: () =>
+          notifyNameMentionUpdates(
+            JORFAllRecordsFromDate,
+            targetApps,
+            messageAppsOptions,
+            windowNow
+          )
+      }
     );
   }
 
   if (JORFMetaRecordsFromDate.length > 0) {
-    await notifyAlertStringUpdates(
-      JORFMetaRecordsFromDate,
-      targetApps,
-      messageAppsOptions,
-      windowNow
-    );
+    handlers.push({
+      name: "alert strings",
+      run: () =>
+        notifyAlertStringUpdates(
+          JORFMetaRecordsFromDate,
+          targetApps,
+          messageAppsOptions,
+          windowNow
+        )
+    });
   }
+
+  // Handlers cover disjoint follow types, so one blowing up says nothing about
+  // the others: run each in isolation and report the failures to the caller
+  // rather than losing every later handler's users to the first throw.
+  const failedHandlers: string[] = [];
+  for (const handler of handlers) {
+    try {
+      await handler.run();
+    } catch (error) {
+      failedHandlers.push(handler.name);
+      await logErrorForApps(
+        targetApps,
+        `Error notifying ${handler.name} follows`,
+        error
+      );
+    }
+  }
+  return failedHandlers;
 }

--- a/tests/20.runNotificationProcess.test.ts
+++ b/tests/20.runNotificationProcess.test.ts
@@ -11,6 +11,7 @@ function emptyRange() {
 const h = vi.hoisted(() => ({
   logErrorSpy: vi.fn(() => Promise.resolve()),
   logErrorForAppsSpy: vi.fn(() => Promise.resolve()),
+  umamiVerifiedSpy: vi.fn(() => Promise.resolve(true)),
   getRecords: vi.fn(() => Promise.resolve(emptyRange())),
   getMeta: vi.fn(() => Promise.resolve(emptyRange())),
   refreshBlocked: vi.fn(() => Promise.resolve()),
@@ -37,7 +38,11 @@ vi.mock("mongoose", () => {
 });
 vi.mock("../db.ts", () => ({ mongodbConnect: vi.fn(() => Promise.resolve()) }));
 vi.mock("../utils/umami.ts", () => ({
-  default: { log: vi.fn(), logAsync: vi.fn(() => Promise.resolve()) }
+  default: {
+    log: vi.fn(),
+    logAsync: vi.fn(() => Promise.resolve()),
+    logAsyncVerified: h.umamiVerifiedSpy
+  }
 }));
 vi.mock("../utils/debugLogger.ts", () => ({
   logError: h.logErrorSpy,
@@ -78,6 +83,7 @@ import type { WhatsAppAPI } from "whatsapp-api-js/middleware/express";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  h.umamiVerifiedSpy.mockResolvedValue(true);
   h.getRecords.mockResolvedValue(emptyRange());
   h.getMeta.mockResolvedValue(emptyRange());
 });
@@ -219,8 +225,8 @@ describe("runNotificationProcess — full run", () => {
     } finally {
       vi.useRealTimers();
     }
-    expect(h.logErrorSpy).toHaveBeenCalledWith(
-      "Telegram",
+    expect(h.logErrorForAppsSpy).toHaveBeenCalledWith(
+      ["Telegram"],
       expect.stringContaining("took too long")
     );
   });
@@ -291,6 +297,93 @@ describe("notifyAllFollows — fan-out", () => {
     for (const spy of [h.notifyOrg, h.notifyPeople, h.notifyName]) {
       expect(spy).toHaveBeenCalledTimes(1);
     }
+  });
+});
+
+describe("runNotificationProcess — outcome reporting", () => {
+  const outcomeOf = (call: unknown[]) =>
+    (call[0] as { payload: { outcome: string } }).payload.outcome;
+
+  it("reports completed on a clean run", async () => {
+    await runNotificationProcess(["Telegram"], { telegramBotToken: "TOK" });
+    expect(h.umamiVerifiedSpy).toHaveBeenCalledTimes(1);
+    expect(outcomeOf(h.umamiVerifiedSpy.mock.calls[0])).toBe("completed");
+  });
+
+  it("reports degraded and names the step when a fetch had a gap", async () => {
+    h.getRecords.mockResolvedValueOnce({
+      items: [{ source_id: "a" }],
+      requestedDays: 2,
+      failedDates: ["2026-08-17"]
+    });
+    await runNotificationProcess(["Telegram"], { telegramBotToken: "TOK" });
+
+    const call = h.umamiVerifiedSpy.mock.calls[0][0] as {
+      payload: { outcome: string; degraded_steps: string };
+    };
+    expect(call.payload.outcome).toBe("degraded");
+    expect(call.payload.degraded_steps).toContain("JORF records fetch");
+  });
+
+  it("reports degraded when a handler failed", async () => {
+    h.getRecords.mockResolvedValueOnce({
+      items: [{ source_id: "a" }],
+      requestedDays: 1,
+      failedDates: []
+    });
+    h.notifyPeople.mockRejectedValueOnce(new Error("boom"));
+    await runNotificationProcess(["Telegram"], { telegramBotToken: "TOK" });
+
+    const call = h.umamiVerifiedSpy.mock.calls[0][0] as {
+      payload: { outcome: string; degraded_steps: string };
+    };
+    expect(call.payload.outcome).toBe("degraded");
+    expect(call.payload.degraded_steps).toContain("people handler");
+  });
+
+  it("still reports when the run aborts", async () => {
+    h.refreshBlocked.mockImplementationOnce(() => {
+      throw new Error("unexpected");
+    });
+    h.getRecords.mockRejectedValueOnce(new Error("and again"));
+    h.getMeta.mockRejectedValueOnce(new Error("and again"));
+    await runNotificationProcess(["Telegram"], { telegramBotToken: "TOK" });
+    expect(h.umamiVerifiedSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports skipped when a client is missing, so the cycle is still counted", async () => {
+    await runNotificationProcess(["Telegram"], {});
+    expect(outcomeOf(h.umamiVerifiedSpy.mock.calls[0])).toBe("skipped");
+  });
+
+  it("reports once per targeted app", async () => {
+    await runNotificationProcess(["Telegram", "Matrix"], {
+      telegramBotToken: "TOK",
+      matrixClient: {} as never
+    });
+    expect(h.umamiVerifiedSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("raises an alert when umami does not record the event", async () => {
+    h.umamiVerifiedSpy.mockResolvedValue(false);
+    await runNotificationProcess(["Telegram"], { telegramBotToken: "TOK" });
+    expect(h.logErrorForAppsSpy).toHaveBeenCalledWith(
+      ["Telegram"],
+      expect.stringContaining("Umami did not record")
+    );
+  });
+
+  it("survives a blocked-user refresh failure and marks the run degraded", async () => {
+    h.refreshBlocked.mockRejectedValueOnce(new Error("telegram down"));
+    await runNotificationProcess(["Telegram"], { telegramBotToken: "TOK" });
+
+    const call = h.umamiVerifiedSpy.mock.calls[0][0] as {
+      payload: { outcome: string; degraded_steps: string };
+    };
+    expect(call.payload.outcome).toBe("degraded");
+    expect(call.payload.degraded_steps).toContain("blocked-user refresh");
+    // The run went on to fetch rather than aborting.
+    expect(h.getRecords).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/20.runNotificationProcess.test.ts
+++ b/tests/20.runNotificationProcess.test.ts
@@ -246,6 +246,35 @@ describe("notifyAllFollows — fan-out", () => {
     expect(h.notifyPeople).not.toHaveBeenCalled();
   });
 
+  it("scopes every handler to the requested users", async () => {
+    const userIds = [{ id: "u1" }] as never;
+
+    await notifyAllFollows(
+      [{ source_id: "a" }] as never,
+      [{ id: "m" }] as never,
+      ["Telegram"],
+      {},
+      windowNow,
+      userIds,
+      true
+    );
+
+    // An on-demand trigger notifies one user: a handler left unscoped would
+    // deliver that user's records to everyone else following the same name or
+    // alert string.
+    for (const spy of [
+      h.notifyFn,
+      h.notifyOrg,
+      h.notifyPeople,
+      h.notifyName,
+      h.notifyAlert
+    ]) {
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][4]).toBe(userIds);
+      expect(spy.mock.calls[0][5]).toBe(true);
+    }
+  });
+
   it("runs the later handlers and reports the failure when one throws", async () => {
     const records = [{ source_id: "a" }] as never;
     h.notifyFn.mockRejectedValueOnce(new Error("tags exploded"));

--- a/tests/20.runNotificationProcess.test.ts
+++ b/tests/20.runNotificationProcess.test.ts
@@ -1,9 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+function emptyRange() {
+  return {
+    items: [] as unknown[],
+    requestedDays: 1,
+    failedDates: [] as string[]
+  };
+}
+
 const h = vi.hoisted(() => ({
   logErrorSpy: vi.fn(() => Promise.resolve()),
-  getRecords: vi.fn(() => Promise.resolve([] as unknown[])),
-  getMeta: vi.fn(() => Promise.resolve([] as unknown[])),
+  logErrorForAppsSpy: vi.fn(() => Promise.resolve()),
+  getRecords: vi.fn(() => Promise.resolve(emptyRange())),
+  getMeta: vi.fn(() => Promise.resolve(emptyRange())),
   refreshBlocked: vi.fn(() => Promise.resolve()),
   reengagement: vi.fn(() => Promise.resolve()),
   notifyFn: vi.fn(() => Promise.resolve()),
@@ -30,7 +39,10 @@ vi.mock("../db.ts", () => ({ mongodbConnect: vi.fn(() => Promise.resolve()) }));
 vi.mock("../utils/umami.ts", () => ({
   default: { log: vi.fn(), logAsync: vi.fn(() => Promise.resolve()) }
 }));
-vi.mock("../utils/debugLogger.ts", () => ({ logError: h.logErrorSpy }));
+vi.mock("../utils/debugLogger.ts", () => ({
+  logError: h.logErrorSpy,
+  logErrorForApps: h.logErrorForAppsSpy
+}));
 vi.mock("../utils/JORFSearch.utils.ts", () => ({
   getJORFRecordsFromDate: h.getRecords,
   getJORFMetaRecordsFromDate: h.getMeta
@@ -65,8 +77,8 @@ import type { WhatsAppAPI } from "whatsapp-api-js/middleware/express";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  h.getRecords.mockResolvedValue([]);
-  h.getMeta.mockResolvedValue([]);
+  h.getRecords.mockResolvedValue(emptyRange());
+  h.getMeta.mockResolvedValue(emptyRange());
 });
 
 describe("runNotificationProcess — missing-client guards", () => {
@@ -120,14 +132,52 @@ describe("runNotificationProcess — full run", () => {
     else delete process.env.NOTIFICATIONS_SHIFT_DAYS;
   });
 
-  it("catches and logs an error thrown mid-run", async () => {
+  it("keeps running the other source when one JORF fetch throws", async () => {
     h.getRecords.mockRejectedValueOnce(new Error("JORF down"));
     await runNotificationProcess(["Telegram"], { telegramBotToken: "TOK" });
-    expect(h.logErrorSpy).toHaveBeenCalledWith(
-      "Telegram",
-      "Error running notification process: ",
+    expect(h.logErrorForAppsSpy).toHaveBeenCalledWith(
+      ["Telegram"],
+      expect.stringContaining("Could not fetch JORF records"),
       expect.any(Error)
     );
+    expect(h.getMeta).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a partially fetched range and still notifies the fetched days", async () => {
+    h.getRecords.mockResolvedValueOnce({
+      items: [{ source_id: "a" }],
+      requestedDays: 3,
+      failedDates: ["2026-08-16"]
+    });
+    await runNotificationProcess(["Telegram"], { telegramBotToken: "TOK" });
+    expect(h.logErrorForAppsSpy).toHaveBeenCalledWith(
+      ["Telegram"],
+      expect.stringContaining("1/3 day(s)")
+    );
+    expect(h.notifyPeople).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the record handlers when no day of the range could be fetched", async () => {
+    h.getRecords.mockResolvedValueOnce({
+      items: [],
+      requestedDays: 2,
+      failedDates: ["2026-08-16", "2026-08-17"]
+    });
+    await runNotificationProcess(["Telegram"], { telegramBotToken: "TOK" });
+    expect(h.logErrorForAppsSpy).toHaveBeenCalledWith(
+      ["Telegram"],
+      expect.stringContaining("JORFSearch is unreachable")
+    );
+    expect(h.notifyPeople).not.toHaveBeenCalled();
+  });
+
+  it("still runs the re-engagement sweep after a JORF outage", async () => {
+    h.getRecords.mockRejectedValueOnce(new Error("JORF down"));
+    h.getMeta.mockRejectedValueOnce(new Error("JORF down"));
+    await runNotificationProcess(["WhatsApp"], {
+      whatsAppAPI: {} as unknown as WhatsAppAPI
+    });
+    expect(h.reengagement).toHaveBeenCalledTimes(1);
   });
 
   it("warns when the run exceeds the duration threshold", async () => {
@@ -136,7 +186,7 @@ describe("runNotificationProcess — full run", () => {
     // end-of-run duration check trips the "took too long" warning.
     h.getRecords.mockImplementationOnce(() => {
       vi.advanceTimersByTime(6 * 60 * 1000);
-      return Promise.resolve([]);
+      return Promise.resolve(emptyRange());
     });
     try {
       await runNotificationProcess(["Telegram"], { telegramBotToken: "TOK" });
@@ -168,5 +218,23 @@ describe("notifyAllFollows — fan-out", () => {
     await notifyAllFollows([], meta, ["Telegram"], {}, windowNow);
     expect(h.notifyAlert).toHaveBeenCalledTimes(1);
     expect(h.notifyPeople).not.toHaveBeenCalled();
+  });
+
+  it("runs the later handlers and reports the failure when one throws", async () => {
+    const records = [{ source_id: "a" }] as never;
+    h.notifyFn.mockRejectedValueOnce(new Error("tags exploded"));
+
+    const failed = await notifyAllFollows(
+      records,
+      [],
+      ["Telegram"],
+      {},
+      windowNow
+    );
+
+    expect(failed).toEqual(["function tags"]);
+    for (const spy of [h.notifyOrg, h.notifyPeople, h.notifyName]) {
+      expect(spy).toHaveBeenCalledTimes(1);
+    }
   });
 });

--- a/tests/20.runNotificationProcess.test.ts
+++ b/tests/20.runNotificationProcess.test.ts
@@ -71,7 +71,8 @@ vi.mock("../notifications/alertStringNotifications.ts", () => ({
 
 import {
   runNotificationProcess,
-  notifyAllFollows
+  notifyAllFollows,
+  coverageCursorFor
 } from "../notifications/runNotificationProcess.ts";
 import type { WhatsAppAPI } from "whatsapp-api-js/middleware/express";
 
@@ -155,6 +156,31 @@ describe("runNotificationProcess — full run", () => {
       expect.stringContaining("1/3 day(s)")
     );
     expect(h.notifyPeople).toHaveBeenCalledTimes(1);
+
+    // Record handlers are held back to just before the gap; the meta range was
+    // complete, so its handler keeps the full window clock.
+    const gapStart = new Date(2026, 7, 16).getTime();
+    const peopleCursor = h.notifyPeople.mock.calls[0][6] as Date;
+    expect(peopleCursor.getTime()).toBe(gapStart - 1);
+  });
+
+  it("clamps only the source that had a gap", async () => {
+    h.getRecords.mockResolvedValueOnce({
+      items: [{ source_id: "a" }],
+      requestedDays: 2,
+      failedDates: ["2026-08-17"]
+    });
+    h.getMeta.mockResolvedValueOnce({
+      items: [{ id: "m" }],
+      requestedDays: 2,
+      failedDates: []
+    });
+    await runNotificationProcess(["Telegram"], { telegramBotToken: "TOK" });
+
+    const peopleCursor = h.notifyPeople.mock.calls[0][6] as Date;
+    const alertCursor = h.notifyAlert.mock.calls[0][6] as Date;
+    expect(peopleCursor.getTime()).toBe(new Date(2026, 7, 17).getTime() - 1);
+    expect(alertCursor.getTime()).toBeGreaterThan(peopleCursor.getTime());
   });
 
   it("skips the record handlers when no day of the range could be fetched", async () => {
@@ -236,5 +262,28 @@ describe("notifyAllFollows — fan-out", () => {
     for (const spy of [h.notifyOrg, h.notifyPeople, h.notifyName]) {
       expect(spy).toHaveBeenCalledTimes(1);
     }
+  });
+});
+
+describe("coverageCursorFor", () => {
+  const windowNow = new Date("2026-08-18T08:00:00Z");
+
+  it("returns the window clock when every day was fetched", () => {
+    expect(coverageCursorFor(windowNow, [])).toEqual(windowNow);
+  });
+
+  it("stops just before the oldest unfetched day", () => {
+    const cursor = coverageCursorFor(windowNow, ["2026-08-17", "2026-08-15"]);
+    const gapStart = new Date(2026, 7, 15);
+
+    expect(cursor.getTime()).toBe(gapStart.getTime() - 1);
+    // A record dated on the gap day stays above the cursor, so a later run
+    // still picks it up.
+    expect(gapStart.getTime()).toBeGreaterThan(cursor.getTime());
+  });
+
+  it("never returns a cursor ahead of the window clock", () => {
+    const cursor = coverageCursorFor(windowNow, ["2027-01-01"]);
+    expect(cursor).toEqual(windowNow);
   });
 });

--- a/tests/27.peopleNotifications.test.ts
+++ b/tests/27.peopleNotifications.test.ts
@@ -23,7 +23,8 @@ vi.mock("../utils/debugLogger.ts", () => ({ logError: logErrorSpy }));
 
 import User, { USER_SCHEMA_VERSION } from "../models/User.ts";
 
-const ZERO_UPDATE = { modifiedCount: 0 } as unknown as Awaited<
+// The follow no longer exists: $max matched nothing to raise.
+const ZERO_UPDATE = { matchedCount: 0, modifiedCount: 0 } as unknown as Awaited<
   ReturnType<typeof User.updateOne>
 >;
 import People from "../models/People.ts";
@@ -310,5 +311,81 @@ describe("sendPeopleUpdate", () => {
     sendMessageSpy.mockResolvedValue(false);
     const map = new Map([["pid", [record()]]]);
     expect(await sendPeopleUpdate(userInfo, map, opts)).toBe(false);
+  });
+});
+
+describe("notifyPeopleUpdates — coverage cursor", () => {
+  it("advances lastUpdate to windowNow when the range is complete", async () => {
+    const person = await makePerson();
+    const user = await makeUser(person._id);
+    const windowNow = new Date("2026-06-21T08:00:00Z");
+
+    await notifyPeopleUpdates([record()], ["Telegram"], opts, windowNow);
+
+    const refreshed = await User.findById(user._id);
+    expect(refreshed?.followedPeople[0].lastUpdate).toEqual(windowNow);
+  });
+
+  it("stops lastUpdate short of an unfetched day so its records stay eligible", async () => {
+    const person = await makePerson();
+    const user = await makeUser(person._id);
+    const windowNow = new Date("2026-06-21T08:00:00Z");
+    // The run covered 2026-06-20 but never fetched 2026-06-21.
+    const cursor = new Date(new Date(2026, 5, 21).getTime() - 1);
+
+    await notifyPeopleUpdates(
+      [record()],
+      ["Telegram"],
+      opts,
+      windowNow,
+      undefined,
+      false,
+      cursor
+    );
+
+    const refreshed = await User.findById(user._id);
+    const stored = refreshed?.followedPeople[0].lastUpdate;
+    expect(stored).toEqual(cursor);
+    // A record published on the unfetched day still sorts above the cursor.
+    expect(new Date(2026, 5, 21).getTime()).toBeGreaterThan(
+      stored?.getTime() ?? 0
+    );
+  });
+
+  it("stays quiet when the follow is already at or past the cursor", async () => {
+    const person = await makePerson();
+    await makeUser(person._id);
+    // Matched the follow, left it untouched because $max found nothing newer.
+    const spy = vi
+      .spyOn(User, "updateOne")
+      .mockResolvedValueOnce({ matchedCount: 1, modifiedCount: 0 } as Awaited<
+        ReturnType<typeof User.updateOne>
+      >);
+
+    await notifyPeopleUpdates([record()], ["Telegram"], opts, new Date());
+
+    expect(logErrorSpy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("never rewinds a follow that is already ahead of the cursor", async () => {
+    const person = await makePerson();
+    const ahead = new Date("2026-06-25T00:00:00Z");
+    const user = await makeUser(person._id, {
+      followedPeople: [{ peopleId: person._id, lastUpdate: ahead }]
+    });
+
+    await notifyPeopleUpdates(
+      [record({ source_date: "2026-06-26" })],
+      ["Telegram"],
+      opts,
+      new Date("2026-06-27T08:00:00Z"),
+      undefined,
+      false,
+      new Date("2026-06-20T00:00:00Z")
+    );
+
+    const refreshed = await User.findById(user._id);
+    expect(refreshed?.followedPeople[0].lastUpdate).toEqual(ahead);
   });
 });

--- a/tests/28.organisationNotifications.test.ts
+++ b/tests/28.organisationNotifications.test.ts
@@ -23,7 +23,8 @@ vi.mock("../utils/debugLogger.ts", () => ({ logError: logErrorSpy }));
 
 import User, { USER_SCHEMA_VERSION } from "../models/User.ts";
 
-const ZERO_UPDATE = { modifiedCount: 0 } as unknown as Awaited<
+// The follow no longer exists: $max matched nothing to raise.
+const ZERO_UPDATE = { matchedCount: 0, modifiedCount: 0 } as unknown as Awaited<
   ReturnType<typeof User.updateOne>
 >;
 import Organisation from "../models/Organisation.ts";

--- a/tests/30.alertStringNotifications.test.ts
+++ b/tests/30.alertStringNotifications.test.ts
@@ -23,7 +23,8 @@ vi.mock("../utils/debugLogger.ts", () => ({ logError: logErrorSpy }));
 
 import User, { USER_SCHEMA_VERSION } from "../models/User.ts";
 
-const ZERO_UPDATE = { modifiedCount: 0 } as unknown as Awaited<
+// The follow no longer exists: $max matched nothing to raise.
+const ZERO_UPDATE = { matchedCount: 0, modifiedCount: 0 } as unknown as Awaited<
   ReturnType<typeof User.updateOne>
 >;
 import {

--- a/tests/31.functionTagNotifications.test.ts
+++ b/tests/31.functionTagNotifications.test.ts
@@ -23,7 +23,8 @@ vi.mock("../utils/debugLogger.ts", () => ({ logError: logErrorSpy }));
 
 import User, { USER_SCHEMA_VERSION } from "../models/User.ts";
 
-const ZERO_UPDATE = { modifiedCount: 0 } as unknown as Awaited<
+// The follow no longer exists: $max matched nothing to raise.
+const ZERO_UPDATE = { matchedCount: 0, modifiedCount: 0 } as unknown as Awaited<
   ReturnType<typeof User.updateOne>
 >;
 import { FunctionTags } from "../entities/FunctionTags.ts";

--- a/tests/39.triggerPending.test.ts
+++ b/tests/39.triggerPending.test.ts
@@ -4,7 +4,7 @@ import mongoose from "mongoose";
 const { logErrorSpy, callRefSpy, notifyAllSpy } = vi.hoisted(() => ({
   logErrorSpy: vi.fn(() => Promise.resolve()),
   callRefSpy: vi.fn(),
-  notifyAllSpy: vi.fn(() => Promise.resolve())
+  notifyAllSpy: vi.fn(() => Promise.resolve([] as string[]))
 }));
 
 vi.mock("../utils/debugLogger.ts", () => ({ logError: logErrorSpy }));
@@ -164,6 +164,26 @@ describe("triggerPendingNotifications", () => {
     await triggerPendingNotifications(
       makeSession(await User.findById(user._id))
     );
+    expect(logErrorSpy).toHaveBeenCalled();
+  });
+
+  it("keeps the pending pile when a handler is reported as failed", async () => {
+    const user = await userWithPending([
+      {
+        notificationType: "organisation",
+        source_ids: ["R1"],
+        insertDate: new Date(),
+        items_nb: 1
+      }
+    ]);
+    notifyAllSpy.mockResolvedValueOnce(["organisations"]);
+
+    await triggerPendingNotifications(
+      makeSession(await User.findById(user._id))
+    );
+
+    const refreshed = await User.findById(user._id);
+    expect(refreshed?.pendingNotifications.length).toBe(1);
     expect(logErrorSpy).toHaveBeenCalled();
   });
 });

--- a/tests/39.triggerPending.test.ts
+++ b/tests/39.triggerPending.test.ts
@@ -126,6 +126,13 @@ describe("triggerPendingNotifications", () => {
 
     expect(callRefSpy).toHaveBeenCalledWith("R1", "Telegram");
     expect(notifyAllSpy).toHaveBeenCalled();
+    // Scoped to the triggering user and forced past the WH window: this is an
+    // on-demand delivery, not a broadcast.
+    const notifyArgs = notifyAllSpy.mock.calls[0] as unknown[];
+    expect((notifyArgs[5] as { toString(): string }[])[0].toString()).toBe(
+      user._id.toString()
+    );
+    expect(notifyArgs[6]).toBe(true);
     const refreshed = await User.findById(user._id);
     expect(refreshed?.pendingNotifications.length).toBe(0);
     expect(refreshed?.waitingReengagement).toBe(false);

--- a/tests/44.jorfSearchFromDate.test.ts
+++ b/tests/44.jorfSearchFromDate.test.ts
@@ -26,7 +26,8 @@ vi.mock("../utils/umami.ts", () => ({
   default: { log: umamiLogSpy, logAsync: umamiLogAsyncSpy }
 }));
 vi.mock("../utils/debugLogger.ts", () => ({
-  logError: vi.fn(() => Promise.resolve())
+  logError: vi.fn(() => Promise.resolve()),
+  logErrorForApps: vi.fn(() => Promise.resolve())
 }));
 
 import {
@@ -55,6 +56,16 @@ function rawMeta(date: string) {
     title: "Titre de test",
     tags: { mesure_nominative: true }
   };
+}
+
+// Mirrors RETRY_MAX in JORFSearch.utils.ts.
+const RETRY_MAX = 5;
+
+// The day URL for the "records" endpoint is keyed on DD-MM-YYYY.
+function dmy(d: Date): string {
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  return `${dd}-${mm}-${String(d.getFullYear())}`;
 }
 
 function ymdMinusOneDay(ymd: string): string {
@@ -87,12 +98,13 @@ describe("getJORFRecordsFromDate", () => {
     const startDate = new Date(today);
     startDate.setDate(today.getDate() - 2); // 3-day range => 3 chunks of size 1
 
-    const results = await getJORFRecordsFromDate(startDate, [
-      "Telegram",
-      "Signal"
-    ]);
+    const { items: results, failedDates } = await getJORFRecordsFromDate(
+      startDate,
+      ["Telegram", "Signal"]
+    );
 
     // One record per day -> 3 total, sorted ascending by source_date.
+    expect(failedDates).toEqual([]);
     expect(results).toHaveLength(3);
     expect(getSpy).toHaveBeenCalledTimes(3);
     for (let i = 1; i < results.length; i++) {
@@ -110,15 +122,82 @@ describe("getJORFRecordsFromDate", () => {
     ).toBe(3);
   });
 
-  it("tolerates a day returning a null/string payload", async () => {
+  it("tolerates a day returning a null/string payload and reports it as failed", async () => {
     getSpy.mockResolvedValue({ data: "error string", request: {} });
 
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    const results = await getJORFRecordsFromDate(new Date(today), ["Telegram"]);
+    const result = await getJORFRecordsFromDate(new Date(today), ["Telegram"]);
 
-    expect(results).toEqual([]);
+    expect(result.items).toEqual([]);
+    expect(result.requestedDays).toBe(1);
+    expect(result.failedDates).toHaveLength(1);
     expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the days that succeeded when another day fails", async () => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const startDate = new Date(today);
+    startDate.setDate(today.getDate() - 1); // 2-day range
+
+    const todayDMY = dmy(today);
+    getSpy.mockImplementation((url: string) => {
+      const m = /(\d{2})-(\d{2})-(\d{4})/.exec(url);
+      // Today is fetched first (the range walks backwards); fail the older day.
+      if (m?.[0] !== todayDMY)
+        return Promise.resolve({ data: "error string", request: {} });
+      const ymd = `${m[3]}-${m[2]}-${m[1]}`;
+      return Promise.resolve({ data: [rawItem(ymd)], request: {} });
+    });
+
+    const result = await getJORFRecordsFromDate(startDate, ["Telegram"]);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.requestedDays).toBe(2);
+    expect(result.failedDates).toHaveLength(1);
+  });
+
+  it("stops requesting further days once JORFSearch is unreachable", async () => {
+    getSpy.mockRejectedValue(
+      Object.assign(new Error("connect ECONNREFUSED"), {
+        isAxiosError: true,
+        toJSON: () => ({})
+      })
+    );
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const startDate = new Date(today);
+    startDate.setDate(today.getDate() - 3); // 4-day range
+
+    // Fake timers so the retry back-off does not cost the test its wall-clock.
+    vi.useFakeTimers();
+    let result;
+    try {
+      const pending = getJORFRecordsFromDate(startDate, ["Telegram"]);
+      await vi.runAllTimersAsync();
+      result = await pending;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(result.items).toEqual([]);
+    // Every day is reported missing, but only the first one burned its retries.
+    expect(result.failedDates).toHaveLength(4);
+    expect(getSpy).toHaveBeenCalledTimes(RETRY_MAX + 1);
+  });
+
+  it("does not mutate the caller's startDate", async () => {
+    getSpy.mockResolvedValue({ data: [], request: {} });
+
+    const startDate = new Date();
+    startDate.setHours(13, 45, 30, 0);
+    const before = startDate.getTime();
+
+    await getJORFRecordsFromDate(startDate, ["Telegram"]);
+
+    expect(startDate.getTime()).toBe(before);
   });
 });
 
@@ -138,7 +217,9 @@ describe("getJORFMetaRecordsFromDate", () => {
     const startDate = new Date(today);
     startDate.setDate(today.getDate() - 2); // 3 chunks of size 1
 
-    const results = await getJORFMetaRecordsFromDate(startDate, ["Telegram"]);
+    const { items: results } = await getJORFMetaRecordsFromDate(startDate, [
+      "Telegram"
+    ]);
 
     expect(results).toHaveLength(3);
     expect(getSpy).toHaveBeenCalledTimes(3);
@@ -159,13 +240,17 @@ describe("getJORFMetaRecordsFromDate", () => {
     expect(umamiLogAsyncSpy).toHaveBeenCalled();
   });
 
-  it("throws when a day returns a null/string payload", async () => {
+  it("reports a failed day instead of throwing", async () => {
     getSpy.mockResolvedValue({ data: "error string", request: {} });
 
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    await expect(
-      getJORFMetaRecordsFromDate(new Date(today), ["Telegram"])
-    ).rejects.toThrow("JORFSearch returned a null value");
+    const result = await getJORFMetaRecordsFromDate(new Date(today), [
+      "Telegram"
+    ]);
+
+    expect(result.items).toEqual([]);
+    expect(result.requestedDays).toBe(1);
+    expect(result.failedDates).toHaveLength(1);
   });
 });

--- a/tests/48.whatsAppMessageText.test.ts
+++ b/tests/48.whatsAppMessageText.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { logWarningSpy } = vi.hoisted(() => ({
+  logWarningSpy: vi.fn(() => Promise.resolve())
+}));
+vi.mock("../utils/debugLogger.ts", () => ({ logWarning: logWarningSpy }));
+
+import { textFromMessage } from "../utils/whatsAppMessageText.ts";
+import type { ServerMessage } from "whatsapp-api-js/types";
+
+const asMessage = (value: unknown) => value as ServerMessage;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("textFromMessage", () => {
+  it("returns null for a missing message instead of throwing", () => {
+    // whatsapp-api-js reads value.messages[0] unconditionally, so a "messages"
+    // change carrying an empty array reaches the emitter with no message.
+    expect(textFromMessage(undefined)).toBeNull();
+    expect(textFromMessage(null)).toBeNull();
+    expect(logWarningSpy).not.toHaveBeenCalled();
+  });
+
+  it("reads plain text bodies", () => {
+    expect(
+      textFromMessage(asMessage({ type: "text", text: { body: "Bonjour" } }))
+    ).toBe("Bonjour");
+  });
+
+  it("reads quick-reply button text", () => {
+    expect(
+      textFromMessage(asMessage({ type: "button", button: { text: "Oui" } }))
+    ).toBe("Oui");
+  });
+
+  it("reads interactive list and button replies", () => {
+    expect(
+      textFromMessage(
+        asMessage({
+          type: "interactive",
+          interactive: { type: "list_reply", list_reply: { title: "Suivis" } }
+        })
+      )
+    ).toBe("Suivis");
+    expect(
+      textFromMessage(
+        asMessage({
+          type: "interactive",
+          interactive: {
+            type: "button_reply",
+            button_reply: { title: "Menu" }
+          }
+        })
+      )
+    ).toBe("Menu");
+  });
+
+  it("returns null for an interactive reply with no title-bearing shape", () => {
+    expect(
+      textFromMessage(
+        asMessage({ type: "interactive", interactive: { type: "nfm_reply" } })
+      )
+    ).toBeNull();
+  });
+
+  it("warns once for a media message and returns null", () => {
+    expect(textFromMessage(asMessage({ type: "image", image: {} }))).toBeNull();
+    expect(logWarningSpy).toHaveBeenCalledWith(
+      "WhatsApp",
+      expect.stringContaining("image")
+    );
+  });
+});

--- a/tests/49.debugLogger.test.ts
+++ b/tests/49.debugLogger.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { postSpy, umamiLogSpy } = vi.hoisted(() => ({
+  postSpy: vi.fn(() => Promise.resolve({ data: {} })),
+  umamiLogSpy: vi.fn()
+}));
+
+vi.mock("axios", () => ({
+  default: {
+    post: postSpy,
+    // Pulled in transitively by the entities barrel debugLogger imports.
+    create: () => ({ get: vi.fn(), post: vi.fn() }),
+    isAxiosError: () => false
+  },
+  isAxiosError: () => false
+}));
+vi.mock("../utils/umami.ts", () => ({ default: { log: umamiLogSpy } }));
+
+process.env.DEBUG_CHAT_ID = "debug-chat-id";
+process.env.TELEGRAM_DEBUG_BOT_TOKEN = "debug-bot-token";
+
+const { logError, logErrorForApps } = await import("../utils/debugLogger.ts");
+
+const sentTexts = () =>
+  postSpy.mock.calls.map(
+    (call) => (call as unknown as [string, { text: string }])[1].text
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("logError", () => {
+  it("does not repeat the error header already present in the stack", async () => {
+    const error = new Error("boom");
+    await logError("Telegram", "Something failed", error);
+
+    const body = sentTexts().join("\n");
+    expect(body.match(/Error: boom/g)).toHaveLength(1);
+  });
+
+  it("keeps the header when the runtime produced no stack", async () => {
+    const error = new Error("boom");
+    error.stack = undefined;
+    await logError("Telegram", "Something failed", error);
+
+    expect(sentTexts().join("\n")).toContain("Error: boom");
+  });
+});
+
+describe("logErrorForApps", () => {
+  it("sends one alert naming every affected app", async () => {
+    await logErrorForApps(
+      ["Telegram", "WhatsApp", "Matrix", "Tchap"],
+      "JORFSearch is unreachable"
+    );
+
+    expect(postSpy).toHaveBeenCalledTimes(1);
+    expect(sentTexts()[0]).toContain("Telegram, WhatsApp, Matrix, Tchap");
+    // Per-app analytics parity is kept even though the alert is shared.
+    expect(umamiLogSpy).toHaveBeenCalledTimes(4);
+  });
+
+  it("sends nothing when no app is affected", async () => {
+    await logErrorForApps([], "nobody cares");
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/50.schedulerResilience.test.ts
+++ b/tests/50.schedulerResilience.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const h = vi.hoisted(() => ({
+  runSpy: vi.fn(() => Promise.resolve()),
+  outcomeSpy: vi.fn(() => Promise.resolve()),
+  logErrorSpy: vi.fn(() => Promise.resolve()),
+  logWarningSpy: vi.fn(() => Promise.resolve())
+}));
+
+vi.mock("../notifications/runNotificationProcess.ts", () => ({
+  runNotificationProcess: h.runSpy,
+  logNotificationOutcome: h.outcomeSpy
+}));
+vi.mock("../utils/debugLogger.ts", () => ({
+  logError: h.logErrorSpy,
+  logWarning: h.logWarningSpy
+}));
+
+import { startDailyNotificationJobs } from "../notifications/notificationScheduler.ts";
+
+const HOUR = 60 * 60 * 1000;
+const savedEnv = { ...process.env };
+
+// 05:00 keeps computeNextOccurrence on the same calendar day, so the configured
+// time decides whether the next occurrence lands ahead of or behind "now".
+const at5am = new Date(2026, 7, 18, 5, 0, 0, 0);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(at5am);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  process.env.NODE_ENV = savedEnv.NODE_ENV;
+  process.env.DAILY_NOTIFICATION_TIME = savedEnv.DAILY_NOTIFICATION_TIME;
+});
+
+describe("startDailyNotificationJobs — surviving a bad next occurrence", () => {
+  it("retries instead of unwinding when the next time cannot be computed", async () => {
+    // In production an occurrence computed in the past throws rather than
+    // rolling forward a day.
+    process.env.NODE_ENV = "production";
+    process.env.DAILY_NOTIFICATION_TIME = "00:01";
+
+    expect(() => {
+      startDailyNotificationJobs(["Telegram"], {});
+    }).not.toThrow();
+
+    expect(h.logErrorSpy).toHaveBeenCalledWith(
+      "Telegram",
+      expect.stringContaining("Could not compute the next notification time"),
+      expect.any(Error)
+    );
+
+    // The retry keeps the loop alive rather than leaving the app silent.
+    const callsBefore = h.logErrorSpy.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(HOUR);
+    expect(h.logErrorSpy.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+});
+
+describe("startDailyNotificationJobs — surviving a hung run", () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = "test";
+    process.env.DAILY_NOTIFICATION_TIME = "09:00";
+  });
+
+  it("reschedules and reports when a run outstays the watchdog", async () => {
+    h.runSpy.mockReturnValueOnce(new Promise<void>(() => undefined));
+
+    startDailyNotificationJobs(["Telegram"], {});
+
+    // 05:00 -> 09:00 fires the run, which then never settles.
+    await vi.advanceTimersByTimeAsync(4 * HOUR);
+    expect(h.runSpy).toHaveBeenCalledTimes(1);
+    expect(h.outcomeSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(6 * HOUR);
+
+    const watchdogCall = h.logErrorSpy.mock.calls.find((call) =>
+      String(call[1]).includes("error during notification process")
+    );
+    expect(watchdogCall).toBeDefined();
+    expect(String((watchdogCall?.[2] as Error | undefined)?.message)).toContain(
+      "still unfinished"
+    );
+    expect(h.outcomeSpy).toHaveBeenCalledWith(
+      ["Telegram"],
+      "failed",
+      0,
+      expect.arrayContaining([expect.stringContaining("watchdog")])
+    );
+  });
+
+  it("counts the cycles a hung run eats instead of going quiet", async () => {
+    h.runSpy.mockReturnValueOnce(new Promise<void>(() => undefined));
+
+    startDailyNotificationJobs(["Telegram"], {});
+    await vi.advanceTimersByTimeAsync(4 * HOUR); // run starts
+    await vi.advanceTimersByTimeAsync(6 * HOUR); // watchdog gives up
+    h.outcomeSpy.mockClear();
+
+    // Next day's occurrence still fires, and is reported as skipped rather
+    // than silently vanishing.
+    await vi.advanceTimersByTimeAsync(24 * HOUR);
+
+    expect(h.outcomeSpy).toHaveBeenCalledWith(
+      ["Telegram"],
+      "skipped",
+      0,
+      expect.arrayContaining([expect.stringContaining("still in progress")])
+    );
+    // The hung run is never started a second time.
+    expect(h.runSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("resumes normally once a slow run finally settles", async () => {
+    let release: (() => void) | undefined;
+    h.runSpy.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        release = () => {
+          resolve();
+        };
+      })
+    );
+
+    startDailyNotificationJobs(["Telegram"], {});
+    await vi.advanceTimersByTimeAsync(4 * HOUR);
+    await vi.advanceTimersByTimeAsync(6 * HOUR); // watchdog gave up
+
+    release?.();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The schedule the watchdog rearmed carries on once the flag is released.
+    await vi.advanceTimersByTimeAsync(24 * HOUR);
+    expect(h.runSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("fires exactly one run per occurrence after a watchdog event", async () => {
+    let release: (() => void) | undefined;
+    h.runSpy.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        release = () => {
+          resolve();
+        };
+      })
+    );
+
+    startDailyNotificationJobs(["Telegram"], {});
+    await vi.advanceTimersByTimeAsync(4 * HOUR);
+    await vi.advanceTimersByTimeAsync(6 * HOUR);
+    release?.();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The watchdog rearmed the schedule while the run was still pending, so
+    // the token check has to keep that from compounding into extra timers.
+    await vi.advanceTimersByTimeAsync(48 * HOUR);
+    expect(h.runSpy).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/51.umamiDelivery.test.ts
+++ b/tests/51.umamiDelivery.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { postSpy } = vi.hoisted(() => ({ postSpy: vi.fn() }));
+
+vi.mock("axios", () => ({
+  default: { create: () => ({ post: postSpy }) },
+  isAxiosError: () => true
+}));
+
+const savedNodeEnv = process.env.NODE_ENV;
+// logInternal short-circuits under test and development; exercise the send path.
+process.env.NODE_ENV = "production";
+process.env.UMAMI_HOST = "umami.example";
+process.env.UMAMI_ID = "site-id";
+
+const { logAsyncVerified } = await import("../utils/umami.ts");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Re-applied per test: logInternal reads NODE_ENV at call time and
+  // short-circuits under "test".
+  process.env.NODE_ENV = "production";
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  process.env.NODE_ENV = savedNodeEnv;
+});
+
+// Delivery is retried with a back-off, so drive the clock rather than waiting.
+const send = async () => {
+  vi.useFakeTimers();
+  const pending = logAsyncVerified({ event: "/stats", messageApp: "Telegram" });
+  await vi.runAllTimersAsync();
+  return await pending;
+};
+
+describe("logAsyncVerified", () => {
+  it("reports success on the first attempt", async () => {
+    postSpy.mockResolvedValue({ data: "ok" });
+    await expect(send()).resolves.toBe(true);
+    expect(postSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a failed send and reports success when it lands", async () => {
+    postSpy
+      .mockRejectedValueOnce(new Error("ECONNRESET"))
+      .mockResolvedValueOnce({ data: "ok" });
+
+    await expect(send()).resolves.toBe(true);
+    expect(postSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports failure once the attempts are exhausted", async () => {
+    postSpy.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    await expect(send()).resolves.toBe(false);
+    expect(postSpy).toHaveBeenCalledTimes(3);
+  });
+});

--- a/utils/JORFSearch.utils.ts
+++ b/utils/JORFSearch.utils.ts
@@ -20,7 +20,7 @@ import {
 } from "../entities/JORFSearchResponseMeta.ts";
 import { FunctionTags } from "../entities/FunctionTags.ts";
 import { dateToString, JORFtoDate } from "./date.utils.ts";
-import { logError } from "./debugLogger.ts";
+import { logError, logErrorForApps } from "./debugLogger.ts";
 import { IPublication, Publication } from "../models/Publication.ts";
 
 // Per Wikimedia policy, provide a descriptive agent with contact info.
@@ -197,56 +197,99 @@ async function callJORFSearchDay(
         return await callJORFSearchDay(day, messageApps, retryNumber + 1);
       } else {
         logJORFSearchError("date");
-        for (const messageApp of messageApps)
-          await logError(
-            messageApp,
-            `JORFSearch request for date aborted after ${String(RETRY_MAX)} tries`,
-            error
-          );
+        await logErrorForApps(
+          messageApps,
+          `JORFSearch request for date aborted after ${String(RETRY_MAX)} tries`,
+          error
+        );
       }
     } else {
-      for (const messageApp of messageApps)
-        await logError(messageApp, "Error in callJORFSearchDay", error);
+      await logErrorForApps(messageApps, "Error in callJORFSearchDay", error);
     }
   }
   return null;
 }
 
-export async function getJORFRecordsFromDate(
-  startDate: Date,
-  messageApps: MessageApp[]
-): Promise<JORFSearchItem[]> {
+/**
+ * A day range fetched from JORFSearch. `failedDates` lists the days (YMD) whose
+ * fetch never succeeded, so callers can tell "nothing was published" apart from
+ * "we could not find out".
+ */
+export interface JORFRangeResult<T> {
+  items: T[];
+  requestedDays: number;
+  failedDates: string[];
+}
+
+/**
+ * Builds the descending list of days from `startDate` up to today, without
+ * mutating the caller's `startDate`.
+ */
+function buildDayRange(startDate: Date): Date[] {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
-  startDate.setHours(0, 0, 0, 0);
+  const from = new Date(startDate);
+  from.setHours(0, 0, 0, 0);
 
   const dayCount =
-    Math.floor((today.getTime() - startDate.getTime()) / 86_400_000) + 1;
-  const days: Date[] = Array.from({ length: dayCount }, (_, i) => {
+    Math.floor((today.getTime() - from.getTime()) / 86_400_000) + 1;
+  return Array.from({ length: dayCount }, (_, i) => {
     const d = new Date(today);
     d.setDate(today.getDate() - i);
     return d;
   });
+}
+
+/**
+ * Walks `days` in chunks of {@link JORFSEARCH_CALLS_CONCURRENCY}, recording the
+ * days that came back empty-handed.
+ *
+ * Once a whole chunk fails, JORFSearch is treated as down and the remaining days
+ * are marked failed without being requested: each day already burns
+ * `RETRY_MAX + 1` attempts, so a multi-day backfill against a dead host would
+ * otherwise spend minutes hammering it before reaching the notification stage.
+ */
+async function fetchDayRange<T>(
+  days: Date[],
+  fetchDay: (day: Date) => Promise<T | null>
+): Promise<{ results: T[]; failedDates: string[] }> {
+  const results: T[] = [];
+  const failedDates: string[] = [];
 
   const limit = JORFSEARCH_CALLS_CONCURRENCY;
-  const chunks: Date[][] = [];
-  for (let i = 0; i < days.length; i += limit)
-    chunks.push(days.slice(i, i + limit));
+  for (let i = 0; i < days.length; i += limit) {
+    const sub = days.slice(i, i + limit);
+    const subResults = await Promise.all(sub.map(fetchDay));
 
-  const resultTab: (JORFSearchDayResult | null)[] = [];
-  for (const sub of chunks) {
-    resultTab.push(
-      ...(await Promise.all(
-        sub.map((day: Date) => callJORFSearchDay(day, messageApps))
-      ))
-    );
+    subResults.forEach((result, j) => {
+      if (result == null) failedDates.push(dateToString(sub[j], "YMD"));
+      else results.push(result);
+    });
+
+    if (subResults.every((result) => result == null)) {
+      for (const day of days.slice(i + limit)) {
+        failedDates.push(dateToString(day, "YMD"));
+      }
+      break;
+    }
   }
 
+  return { results, failedDates };
+}
+
+export async function getJORFRecordsFromDate(
+  startDate: Date,
+  messageApps: MessageApp[]
+): Promise<JORFRangeResult<JORFSearchItem>> {
+  const days = buildDayRange(startDate);
+
+  const { results, failedDates } = await fetchDayRange(days, (day) =>
+    callJORFSearchDay(day, messageApps)
+  );
+
   const allResults: JORFSearchDayResult = {
-    items: resultTab.flatMap((r) => r?.items ?? []),
-    stats: mergeJORFSearchItemCleaningStats(
-      resultTab.flatMap((r) => r?.stats ?? [])
-    )
+    items: results.flatMap((r) => r.items),
+    stats: mergeJORFSearchItemCleaningStats(results.flatMap((r) => r.stats))
   };
 
   // Log aggregated statistics once per app
@@ -256,15 +299,21 @@ export async function getJORFRecordsFromDate(
       messageApp,
       payload: {
         ...allResults.stats,
-        day_nb: dayCount
+        day_nb: days.length,
+        failed_day_nb: failedDates.length
       }
     });
   }
 
-  return allResults.items.sort(
-    (a, b) =>
-      JORFtoDate(a.source_date).getTime() - JORFtoDate(b.source_date).getTime()
-  );
+  return {
+    items: allResults.items.sort(
+      (a, b) =>
+        JORFtoDate(a.source_date).getTime() -
+        JORFtoDate(b.source_date).getTime()
+    ),
+    requestedDays: days.length,
+    failedDates
+  };
 }
 
 export interface JORFSearchMetaDayResult {
@@ -331,15 +380,17 @@ export async function callJORFSearchMetaDay(
         );
       }
       logJORFSearchError("meta");
-      for (const messageApp of messageApps)
-        await logError(
-          messageApp,
-          `JORFSearch request for meta aborted after ${String(RETRY_MAX)} tries`,
-          error
-        );
+      await logErrorForApps(
+        messageApps,
+        `JORFSearch request for meta aborted after ${String(RETRY_MAX)} tries`,
+        error
+      );
     } else {
-      for (const messageApp of messageApps)
-        await logError(messageApp, "Error in callJORFSearchMetaDay", error);
+      await logErrorForApps(
+        messageApps,
+        "Error in callJORFSearchMetaDay",
+        error
+      );
     }
   }
   return null;
@@ -348,34 +399,13 @@ export async function callJORFSearchMetaDay(
 export async function getJORFMetaRecordsFromDate(
   startDate: Date,
   messageApps: MessageApp[]
-): Promise<JORFSearchPublication[]> {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  startDate.setHours(0, 0, 0, 0);
+): Promise<JORFRangeResult<JORFSearchPublication>> {
+  const days = buildDayRange(startDate);
 
-  const dayCount =
-    Math.floor((today.getTime() - startDate.getTime()) / 86_400_000) + 1;
-  const days: Date[] = Array.from({ length: dayCount }, (_, i) => {
-    const d = new Date(today);
-    d.setDate(today.getDate() - i);
-    return d;
-  });
-
-  const limit = JORFSEARCH_CALLS_CONCURRENCY;
-  const chunks: Date[][] = [];
-  for (let i = 0; i < days.length; i += limit)
-    chunks.push(days.slice(i, i + limit));
-
-  const results: (JORFSearchMetaDayResult | null)[] = [];
-  for (const sub of chunks) {
-    results.push(
-      ...(await Promise.all(
-        sub.map((day: Date) =>
-          callJORFSearchMetaDay(day, messageApps, 0, false)
-        ) // saveTodB is false to save to dB in batch
-      ))
-    );
-  }
+  const { results, failedDates } = await fetchDayRange(
+    days,
+    (day) => callJORFSearchMetaDay(day, messageApps, 0, false) // saved to dB in batch below
+  );
 
   const allItems: JORFSearchPublication[] = [];
   let totalRawItems = 0;
@@ -383,7 +413,6 @@ export async function getJORFMetaRecordsFromDate(
   let totalDroppedItems = 0;
 
   for (const result of results) {
-    if (result == null) throw new Error("JORFSearch returned a null value");
     allItems.push(...result.items);
     totalRawItems += result.stats.raw_item_nb;
     totalCleanItems += result.stats.clean_item_nb;
@@ -399,7 +428,8 @@ export async function getJORFMetaRecordsFromDate(
         raw_item_nb: totalRawItems,
         clean_item_nb: totalCleanItems,
         dropped_item_nb: totalDroppedItems,
-        day_nb: dayCount
+        day_nb: days.length,
+        failed_day_nb: failedDates.length
       }
     });
   }
@@ -410,7 +440,7 @@ export async function getJORFMetaRecordsFromDate(
 
   await saveMetaPublications(allItems, messageApps);
 
-  return allItems;
+  return { items: allItems, requestedDays: days.length, failedDates };
 }
 
 export async function callJORFSearchTag(

--- a/utils/debugLogger.ts
+++ b/utils/debugLogger.ts
@@ -67,7 +67,13 @@ console.info = (...args: unknown[]) => {
 const formatError = (error: unknown): string | null => {
   if (error == null) return null;
   if (error instanceof Error) {
-    return `${error.name}: ${error.message}${error.stack ? `\n${error.stack}` : ""}`;
+    const header = `${error.name}: ${error.message}`;
+    // V8 stacks already start with "Name: message"; only prepend the header when
+    // the runtime omitted it, otherwise every alert repeats its first line.
+    if (error.stack == null) return header;
+    return error.stack.startsWith(header)
+      ? error.stack
+      : `${header}\n${error.stack}`;
   }
   if (typeof error === "string") return error;
   try {
@@ -176,7 +182,9 @@ const logToConsole = (
 
 const buildLogMessage = (
   level: LogLevel,
-  messageApp: MessageApp,
+  // Free-form label: a single MessageApp, or a comma-joined list when one
+  // failure affects several apps.
+  messageApp: string,
   message: string,
   error?: unknown
 ): string => {
@@ -211,5 +219,32 @@ export const logError = async (
   umami.log({ event: "/console-log", messageApp });
   await sendTelegramDebugMessage(
     buildLogMessage("error", messageApp, message, error)
+  );
+};
+
+/**
+ * Reports a single failure that affects several apps at once (a shared
+ * dependency being down, for instance). Emits one Telegram alert naming every
+ * affected app instead of one alert per app: `sendTelegramDebugMessage` sleeps
+ * {@link TELEGRAM_COOL_DOWN_DELAY_SECONDS} between sends, so fanning a shared
+ * failure out per app both spams the channel and stalls the caller.
+ * Umami still records one event per app so per-app error rates stay comparable.
+ */
+export const logErrorForApps = async (
+  messageApps: MessageApp[],
+  message: string,
+  error?: unknown
+): Promise<void> => {
+  if (messageApps.length === 0) return;
+  if (messageApps.length === 1) {
+    await logError(messageApps[0], message, error);
+    return;
+  }
+  logToConsole("error", message, error);
+  for (const messageApp of messageApps) {
+    umami.log({ event: "/console-log", messageApp });
+  }
+  await sendTelegramDebugMessage(
+    buildLogMessage("error", messageApps.join(", "), message, error)
   );
 };

--- a/utils/umami.ts
+++ b/utils/umami.ts
@@ -60,15 +60,22 @@ const axiosClient = axios.create({
 // Shared limiter to cap concurrent send attempts across all log calls.
 const limit = pLimit(5);
 
-const logInternal = async (args: UmamiLogArgs) => {
-  if (process.env.NODE_ENV === "test") return;
+// Umami is the only record that a scheduled run happened at all, so a dropped
+// event is indistinguishable from a run that never started. Retry before
+// giving up.
+const SEND_MAX_ATTEMPTS = 3;
+const SEND_RETRY_DELAY_MS = 500;
+
+// Resolves to false when the event did not reach Umami.
+const logInternal = async (args: UmamiLogArgs): Promise<boolean> => {
+  if (process.env.NODE_ENV === "test") return true;
   if (process.env.NODE_ENV === "development") {
     console.log(
       `Umami event ${args.messageApp ? "(" + args.messageApp + ")" : ""}: ${args.event}`
     );
     if (args.notificationData != null || args.payload != null)
       console.log({ ...args.notificationData, ...args.payload });
-    return;
+    return true;
   } else {
     if (args.messageApp === "debug") {
       throw new Error(
@@ -85,19 +92,29 @@ const logInternal = async (args: UmamiLogArgs) => {
         "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/115.0"
     }
   };
-  await limit(async () => {
-    try {
-      await axiosClient.post(endpoint, payload, options);
-    } catch (error) {
-      if (isAxiosError(error)) {
-        const axiosErr = error as AxiosError;
-        console.error(
-          `Axios error on umami.log "${args.event}" : ${axiosErr.code ? " " + axiosErr.code : ""} ${axiosErr.message}`
-        );
-      } else {
-        console.log(error);
+  return await limit(async () => {
+    for (let attempt = 1; attempt <= SEND_MAX_ATTEMPTS; attempt++) {
+      try {
+        await axiosClient.post(endpoint, payload, options);
+        return true;
+      } catch (error) {
+        if (attempt < SEND_MAX_ATTEMPTS) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, SEND_RETRY_DELAY_MS * attempt)
+          );
+          continue;
+        }
+        if (isAxiosError(error)) {
+          const axiosErr = error as AxiosError;
+          console.error(
+            `Axios error on umami.log "${args.event}" : ${axiosErr.code ? " " + axiosErr.code : ""} ${axiosErr.message}`
+          );
+        } else {
+          console.log(error);
+        }
       }
     }
+    return false;
   });
 };
 
@@ -114,9 +131,17 @@ export const logAsync: UmamiLogger = async (
   await logInternal(args);
 };
 
+/**
+ * Like {@link logAsync}, but reports whether the event actually reached Umami.
+ * Use it for events whose absence is itself the signal being measured.
+ */
+export const logAsyncVerified = async (args: UmamiLogArgs): Promise<boolean> =>
+  await logInternal(args);
+
 export default {
   log,
-  logAsync
+  logAsync,
+  logAsyncVerified
 };
 
 export type UmamiEvent =

--- a/utils/whatsAppMessageText.ts
+++ b/utils/whatsAppMessageText.ts
@@ -1,0 +1,50 @@
+import type { ServerMessage } from "whatsapp-api-js/types";
+
+import { logWarning } from "./debugLogger.ts";
+
+/**
+ * Pick a printable fragment from any WhatsApp inbound message.
+ * Returns `null` when there is nothing reasonably textual.
+ */
+export function textFromMessage(
+  msg: ServerMessage | undefined | null
+): string | null {
+  // Meta can deliver a "messages" change whose `messages` array is empty; the
+  // client library still indexes [0] and hands us `undefined`.
+  if (msg == null) return null;
+
+  switch (msg.type) {
+    //  Plain text
+    case "text":
+      return msg.text.body;
+
+    // Quick-reply buttons
+    case "button":
+      return msg.button.text;
+
+    //  Interactive replies (List, Reply-button, Flow)  */
+    case "interactive":
+      switch (msg.interactive.type) {
+        case "list_reply":
+          return msg.interactive.list_reply.title;
+        case "button_reply":
+          return msg.interactive.button_reply.title;
+        /*
+      case "nfm_reply": // Flow submission
+        return (
+          msg.interactive.nfm_reply.body ??
+          msg.interactive.nfm_reply.response_json ??
+          null);
+        */
+      }
+      return null;
+
+    /*  Catch-all for anything the API marks
+         as unsupported or future types  */
+    default:
+      // Media, stickers, locations and future types: expected user behaviour,
+      // not a fault.
+      void logWarning("WhatsApp", `Unsupported message type: ${msg.type}`);
+      return null;
+  }
+}


### PR DESCRIPTION
Audit of a week of production error logs, then fixes for each root cause found.

Three distinct failures showed up, and the notification pipeline turned all of them into more damage than they needed to cause.

## 1. WhatsApp webhook crash loop

`whatsapp-api-js` reads `value.messages[0]` unconditionally and derives `from` as `contact?.wa_id ?? message.from`. When Meta sends a `messages` change with an empty `messages` array plus a `contacts` entry, the `??` short-circuits and `message` reaches our emitter as `undefined`. `textFromMessage` read `msg.type` and threw.

The five identical log entries were one payload, not five: the throw escaped `on.message`, escaped `whatsAppAPI.post()`, and the webhook replied `500`, so Meta redelivered the same unprocessable payload on its retry schedule.

- `textFromMessage` moved to `utils/whatsAppMessageText.ts` (the app module runs an IIFE on import, so it could not be unit tested where it was) and returns `null` for a nullish message.
- The `on.message` body is wrapped so a handler fault can never reach `post()`.
- Webhook errors now reply with the `httpStatus` the library attached (401 on a bad signature, 400 on a malformed payload) instead of a blanket 500. Unclassified errors keep the retryable 500.
- Unsupported message types (images, stickers) downgraded from `logError` to `logWarning`: that is normal user behaviour, not a fault.

## 2. One bad day killed the whole run

`getJORFMetaRecordsFromDate` threw whenever any single day came back null. That reached the one big `try/catch` in `runNotificationProcess`, so **every user on all four platforms got nothing** because one day's meta fetch failed. `getJORFRecordsFromDate` had the opposite flaw and swallowed day failures silently, making an outage indistinguishable from "nothing was published".

Both now return `{ items, requestedDays, failedDates }`, and the run degrades instead of aborting:

- The two sources are fetched independently, so a meta outage no longer costs people, organisation and tag notifications.
- Partial range: notify for the days that were fetched, report the gap.
- Whole range failed: skip only that source's handlers.
- `notifyAllFollows` runs its five handlers in isolation and returns the names of the ones that failed. Previously a throw in the first handler silently cost the other four their users.
- The WhatsApp re-engagement sweep has nothing to do with JORFSearch and now still runs after a fetch or handler failure.
- A circuit breaker stops requesting further days once JORFSearch is confirmed unreachable, instead of burning `RETRY_MAX + 1` attempts per day against a dead host.

## 3. Follows skipped over days that were never fetched

Handlers move each follow's `lastUpdate` forward on delivery. With a partial range that silently stepped over the unfetched days, so their records were never revisited: permanent, invisible loss.

`coverageCursorFor` computes how far a range is actually known to be complete: `windowNow` when nothing failed, otherwise the last millisecond before the oldest unfetched day starts. Records dated on the gap day stay above the cursor and remain eligible on a later run.

Kept deliberately separate from `windowNow`. Rewinding the window clock would make `reengagementExpired` read false for WhatsApp users who really are expired, pushing sends outside their 24h window and into 131047 errors.

Every `lastUpdate` write moved from `$set` to `$max`. This is load-bearing rather than cosmetic: a backfill whose oldest day failed yields a cursor near `startDate`, which for a follow last updated yesterday would have been a multi-day rewind and a flood of re-sent notifications. `$max` makes the write monotonic in the database, so a clamped cursor can only hold a follow still, never move it backwards.

That changed what a zero count means, so the four affected handlers check `matchedCount === 0` instead of `modifiedCount === 0`. Under `$max`, `modifiedCount: 0` legitimately means "already up to date", and the old check would have fired a false `No lastUpdate updated` alert on every such write. `alertStringNotifications` selected its array elements purely through `arrayFilters`, so its query matched any surviving user; the element condition is now in the filter to keep that diagnostic meaningful.

### Known limitation

Days after a gap that were delivered this run will be delivered again next run. A single watermark per follow cannot express "covered A and C but not B"; that needs per-day coverage state, which is a schema change. Bounded duplicates beat silent permanent loss, and `$max` keeps the duplication bounded. The alert names the oldest gap date and says explicitly that follows were not advanced past it.

## 4. Cross-user leak on the on-demand path

Found while threading the cursor. `notifyAllFollows` called `notifyNameMentionUpdates` and `notifyAlertStringUpdates` with four arguments where the others got six, so those two never received `userIds` or `forceWHMessages` even though both implement them fully.

The daily run passes `undefined` / `false`, so it was unaffected. `triggerPendingNotifications` passes a single user id and `true`, and three of five handlers honoured it. The other two queried **every** active user with `followedNames` / `followedMeta`. One user tapping their pending pile therefore ran a mini broadcast: anyone else following the same name or alert string got those records off-schedule, judged against the triggering user's clock, with their cursors advanced. WhatsApp users caught in it and outside their own window were queued and templated as a side effect of someone else's tap.

Both now receive the same scope as the rest, and the invariant is documented on the parameter.

## Logging

- `formatError` no longer prints the `Name: message` header twice. V8 stacks already start with it, which is why every entry in the log had a doubled first line.
- New `logErrorForApps`: one Telegram alert naming all affected apps for a shared failure, with per-app umami events preserved. A shared failure previously sent one alert per app, each with a cooldown, stalling the caller in the notification hot path.
- `buildDayRange` no longer mutates the caller's `startDate` (both fetchers were handed the same `Date` object).

## Tests

796 passing across 55 files. Four new suites (`48.whatsAppMessageText`, `49.debugLogger`, `50.schedulerResilience`, `51.umamiDelivery`) and new cases in `20`, `27`, `39`, `44` covering partial ranges, all-days-failed, the circuit breaker, handler isolation, cursor clamping, `$max` monotonicity, handler scoping, pending-queue preservation, every outcome value, umami retry and failure reporting, watchdog recovery and schedule-token behaviour.


---

## 5. A missing telemetry event meant five different things

Prompted by ~20 missing `/notification-process-completed` events over a week. The logged JORFSearch aborts explain 12 of them (3 cycles × 4 apps, all the throw removed above). The rest could not be attributed, because a missing event conflated "the run crashed", "the cycle was skipped", "umami rejected the POST" and "the process was not running". Each is now separated.

**The event always fires.** It moved into a `finally` and carries an `outcome` of `completed` / `degraded` / `failed` / `skipped`, plus `degraded_steps` naming what was lost. Every fired schedule now emits exactly one event per app whatever happens to it, so a missing event has one remaining meaning: the process was not running.

**The send is verified.** `umami.logInternal` caught the axios failure and wrote `console.error`, so a dropped event looked identical to a run that never happened. It now retries three times with a back-off and reports whether the event landed; `logAsyncVerified` exposes that, and the caller raises a Telegram alert when it does not. Fire-and-forget `log` is unchanged.

**`refreshTelegramBlockedUsers` no longer takes the run down.** It ran unguarded before the fetches. Its failure only costs us the chance to pre-skip users who already blocked the bot — their sends fail individually and are handled per user — so it is now caught and recorded as a degradation.

## 6. Two ways the scheduler could stop forever

Both silent, both permanent until someone restarted the process.

**A reschedule that throws.** `scheduleNextRun()` is called from a `finally`. If `computeNextOccurrence` throws there — it can, in production, on "computed time is in the past" or a negative shift index — the throw escaped a `void (async () => …)()` as an unhandled rejection and the next occurrence was never armed. It is now caught, logged, and retried hourly.

**A run that never settles.** The next occurrence is only armed once the current one finishes, so a single hung run ended the schedule permanently. A 6-hour watchdog now bounds the wait: well above any legitimate run (the slow-run warning trips at 5 minutes), well under the daily cadence. The run cannot be cancelled, so the scheduler reschedules around it and the still-running guard reports each cycle the hang eats as `skipped` rather than letting the schedule go quiet. The flag that guard reads is bound to the run promise rather than to the watchdog's wait, so a run the watchdog gave up on still releases it if it later settles.

That guard was unreachable before this change: exactly one timer existed at a time, so `running` was never true when a schedule fired. The watchdog is what makes overlap possible, so a monotonic schedule token now ensures only the most recently armed timer acts and the two chains cannot compound.
