### PR TITLE
fix: tame Matrix log noise and source meta publications from Legifrance

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -32,12 +32,15 @@ WHATSAPP_VERIFY_TOKEN=""
 WHATSAPP_APP_PORT="3000"
 WHATSAPP_PHONE_ID=""
 
+# Bare host, without a scheme: the app prefixes "https://".
 MATRIX_HOME_URL=""
 MATRIX_BOT_USERNAME=""
 MATRIX_BOT_PASSWORD=""
 MATRIX_BOT_TOKEN=""
+# "Matrix" or "Tchap": selects which bot the matrix app runs as.
+MATRIX_BOT_TYPE="Matrix"
 
-MATRIX_BOT_ENCRYPTION=TRUE
+MATRIX_ENCRYPTION_ENABLED=TRUE
 
 SIGNAL_PHONE_NUMBER=""
 SIGNAL_DEVICE_NAME=""

--- a/.env.template
+++ b/.env.template
@@ -12,6 +12,14 @@ NTBA_FIX_350=true
 DAILY_NOTIFICATION_TIME="09:00"
 NOTIFICATIONS_SHIFT_DAYS=15
 
+# Legifrance (DILA) API, used for the JO summaries behind meta publications.
+# Free registration on https://piste.gouv.fr, then create an application to get
+# the OAuth client credentials.
+# Sandbox: https://sandbox-api.piste.gouv.fr/dila/legifrance-beta/lf-engine-app
+LEGIFRANCE_CLIENT_ID=""
+LEGIFRANCE_CLIENT_SECRET=""
+LEGIFRANCE_API_URL="https://api.piste.gouv.fr/dila/legifrance/lf-engine-app"
+
 # Text search configuration
 # Number of years to search back in publication history (default: 2, max: 50)
 TEXT_SEARCH_YEARS_BACK=2

--- a/apps/matrixApp.ts
+++ b/apps/matrixApp.ts
@@ -13,7 +13,22 @@ import { startDailyNotificationJobs } from "../notifications/notificationSchedul
 import User from "../models/User.ts";
 import { IUser } from "../types.ts";
 import { KEYBOARD_KEYS } from "../entities/Keyboard.ts";
-import { logError, logWarning } from "../utils/debugLogger.ts";
+import {
+  logError,
+  logTelegramDebugStatus,
+  logWarning
+} from "../utils/debugLogger.ts";
+import {
+  isBlankEnv,
+  missingEnvVars,
+  parseBooleanEnv
+} from "../utils/env.utils.ts";
+import { configureMatrixLogging } from "../utils/matrixLogService.ts";
+import {
+  attachSyncHealth,
+  createSyncHealth,
+  SyncingClient
+} from "../utils/matrixSyncHealth.ts";
 import { handleIncomingMessage } from "../utils/messageWorkflow.ts";
 // Persist sync token + crypto state
 import fs from "node:fs";
@@ -21,11 +36,18 @@ import { StoreType } from "@matrix-org/matrix-sdk-crypto-nodejs";
 
 const { MATRIX_HOME_URL, MATRIX_BOT_TOKEN, MATRIX_BOT_TYPE } = process.env;
 if (
-  MATRIX_HOME_URL == undefined ||
-  MATRIX_BOT_TOKEN == undefined ||
-  MATRIX_BOT_TYPE == undefined
+  isBlankEnv(MATRIX_HOME_URL) ||
+  isBlankEnv(MATRIX_BOT_TOKEN) ||
+  isBlankEnv(MATRIX_BOT_TYPE)
 ) {
-  console.log(`Matrix: env is not set, bot did not start \u{1F6A9}`);
+  const missing = missingEnvVars({
+    MATRIX_HOME_URL,
+    MATRIX_BOT_TOKEN,
+    MATRIX_BOT_TYPE
+  });
+  console.log(
+    `Matrix: env is not set (missing: ${missing.join(", ")}), bot did not start \u{1F6A9}`
+  );
   process.exit(0);
 }
 
@@ -37,9 +59,15 @@ if (!["Matrix", "Tchap"].some((m) => m === MATRIX_BOT_TYPE)) {
 }
 const matrixApp = MATRIX_BOT_TYPE as "Matrix" | "Tchap";
 
+// Summarize the SDK's own output before it emits anything: unconfigured, it
+// prints whole error bodies and untagged lines shared with the other bots.
+configureMatrixLogging(matrixApp);
+logTelegramDebugStatus();
+
 // Global constant to check if encryption is enabled for the bot
-export const MATRIX_ENCRYPTION_ENABLED = Boolean(
-  process.env.MATRIX_ENCRYPTION_ENABLED ?? "TRUE"
+export const MATRIX_ENCRYPTION_ENABLED = parseBooleanEnv(
+  process.env.MATRIX_ENCRYPTION_ENABLED,
+  true
 );
 
 if (MATRIX_ENCRYPTION_ENABLED) {
@@ -73,6 +101,13 @@ const client = MATRIX_ENCRYPTION_ENABLED
       MATRIX_BOT_TOKEN,
       storageProvider
     );
+
+// The sync loop retries forever and only writes to the SDK logger, so without
+// this an outage is invisible outside stdout.
+attachSyncHealth(
+  client as unknown as SyncingClient,
+  createSyncHealth(matrixApp)
+);
 
 AutojoinRoomsMixin.setupOnClient(client);
 AutojoinUpgradedRoomsMixin.setupOnClient(client); // optional but nice to have
@@ -316,6 +351,12 @@ await (async function () {
     console.log(`${matrixApp}: JOEL started successfully \u{2705}`);
   } catch (error) {
     await logError(matrixApp, "Failed to start app", error);
+    // Mongoose keeps the event loop alive, so returning here would leave a
+    // process that syncs nothing and schedules no notifications while the
+    // container still reports as healthy.
+    process.exitCode = 1;
+    await mongodbDisconnect().catch(() => undefined);
+    process.exit(1);
   }
 })();
 

--- a/commands/triggerPendingNotifications.ts
+++ b/commands/triggerPendingNotifications.ts
@@ -79,8 +79,11 @@ export const triggerPendingNotifications = async (
     const limit = pLimit(FETCH_CONCURRENCY);
     const itemsOut = new Map<JORFReference, JORFSearchItem[]>(); // keep order
 
+    // The same reference can appear in several pending batches; fetch it once.
+    const uniqueReferences = [...new Set(source_id_items)];
+
     await Promise.all(
-      source_id_items.map((ref) =>
+      uniqueReferences.map((ref) =>
         limit(async () => {
           const res = await callJORFSearchReference(ref, session.messageApp);
           if (res == null) {
@@ -96,7 +99,7 @@ export const triggerPendingNotifications = async (
     );
 
     const candidateJORFPublications: JORFSearchPublication[] =
-      await Publication.find({ source_id: { $in: source_id_publications } });
+      await Publication.find({ id: { $in: source_id_publications } });
 
     const candidateJORFSearchItems: JORFSearchItem[] = Array.from(
       itemsOut.values()

--- a/notifications/runNotificationProcess.ts
+++ b/notifications/runNotificationProcess.ts
@@ -56,6 +56,7 @@ export function coverageCursorFor(
 
 async function fetchRange<T>(
   label: string,
+  source: string,
   fetch: () => Promise<JORFRangeResult<T>>,
   targetApps: MessageApp[],
   windowNow: Date
@@ -66,7 +67,7 @@ async function fetchRange<T>(
   } catch (error) {
     await logErrorForApps(
       targetApps,
-      `Could not fetch JORF ${label}: the matching notifications are skipped for this run.`,
+      `Could not fetch ${label}: the matching notifications are skipped for this run.`,
       error
     );
     return { items: [], coverageCursor: windowNow, degraded: true };
@@ -80,8 +81,8 @@ async function fetchRange<T>(
   await logErrorForApps(
     targetApps,
     allDaysFailed
-      ? `JORFSearch is unreachable for ${label}: no day of the range could be fetched, the matching notifications are skipped for this run.`
-      : `JORFSearch returned no data for ${String(range.failedDates.length)}/${String(range.requestedDays)} day(s) of ${label} (${range.failedDates.join(", ")}). Notifications are sent for the days that were fetched, and follows are not advanced past ${range.failedDates.reduce((a, b) => (a < b ? a : b))} so the gap is picked up on a later run.`
+      ? `${source} is unreachable for ${label}: no day of the range could be fetched, the matching notifications are skipped for this run.`
+      : `${source} returned no data for ${String(range.failedDates.length)}/${String(range.requestedDays)} day(s) of ${label} (${range.failedDates.join(", ")}). Notifications are sent for the days that were fetched, and follows are not advanced past ${range.failedDates.reduce((a, b) => (a < b ? a : b))} so the gap is picked up on a later run.`
   );
 
   // A fully failed range is indistinguishable from "nothing was published", and
@@ -254,13 +255,15 @@ export async function runNotificationProcess(
     // Each source is fetched independently: one being unreachable must not cost
     // users the notifications the other one can still deliver.
     const records = await fetchRange(
-      "records",
+      "JORF records",
+      "JORFSearch",
       () => getJORFRecordsFromDate(startDate, targetApps),
       targetApps,
       start
     );
     const metaRecords = await fetchRange(
       "meta publications",
+      "Legifrance",
       () => getJORFMetaRecordsFromDate(startDate, targetApps),
       targetApps,
       start

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "type": "module",
   "scripts": {
-    "start": "npm start:prod",
-    "start:dev": "concurrently \"npm run start-tg\" \"npm run start-wh\" \"npm run start-mx\"",
+    "start": "npm run start:prod",
+    "start:dev": "concurrently -n tg,wh,mx --kill-others-on-fail \"npm run start-tg\" \"npm run start-wh\" \"npm run start-mx\"",
     "start-mx": "tsx apps/matrixApp.ts",
     "start-tg": "tsx apps/telegramApp.ts",
     "start-wh": "tsx apps/whatsAppApp.ts",
     "start-si": "tsx apps/signalApp.ts",
     "build": "tsc -p tsconfig.build.json",
-    "start:prod": "concurrently \"npm run start-tg:prod\" \"npm run start-wh:prod\" \"npm run start-mx:prod\"",
+    "start:prod": "concurrently -n tg,wh,mx --kill-others-on-fail \"npm run start-tg:prod\" \"npm run start-wh:prod\" \"npm run start-mx:prod\"",
     "start-mx:prod": "node dist/apps/matrixApp.js",
     "start-tg:prod": "node dist/apps/telegramApp.js",
     "start-wh:prod": "node dist/apps/whatsAppApp.js",

--- a/tests/39.triggerPending.test.ts
+++ b/tests/39.triggerPending.test.ts
@@ -93,7 +93,6 @@ describe("triggerPendingNotifications", () => {
   it("fetches refs, dispatches and clears the pending pile", async () => {
     await Publication.create({
       id: "M1",
-      source_id: "M1",
       date: "2026-06-20",
       date_obj: new Date(),
       title: "Decret",
@@ -133,9 +132,64 @@ describe("triggerPendingNotifications", () => {
       user._id.toString()
     );
     expect(notifyArgs[6]).toBe(true);
+    // Publications are keyed by `id`; a lookup on any other field returns
+    // nothing and the pending pile is cleared without delivering them.
+    expect((notifyArgs[1] as { id: string }[]).map((p) => p.id)).toEqual([
+      "M1"
+    ]);
     const refreshed = await User.findById(user._id);
     expect(refreshed?.pendingNotifications.length).toBe(0);
     expect(refreshed?.waitingReengagement).toBe(false);
+  });
+
+  it("delivers a pending alert-string notification on its own", async () => {
+    await Publication.create({
+      id: "M2",
+      date: "2026-06-21",
+      date_obj: new Date(),
+      title: "Arrete",
+      tags: {}
+    });
+    const user = await userWithPending([
+      {
+        notificationType: "meta",
+        source_ids: ["M2"],
+        insertDate: new Date(),
+        items_nb: 1
+      }
+    ]);
+
+    await triggerPendingNotifications(
+      makeSession(await User.findById(user._id))
+    );
+
+    const notifyArgs = notifyAllSpy.mock.calls[0] as unknown[];
+    expect((notifyArgs[1] as { id: string }[]).map((p) => p.id)).toEqual([
+      "M2"
+    ]);
+  });
+
+  it("fetches a reference repeated across batches only once", async () => {
+    const user = await userWithPending([
+      {
+        notificationType: "people",
+        source_ids: ["R1"],
+        insertDate: new Date(),
+        items_nb: 1
+      },
+      {
+        notificationType: "organisation",
+        source_ids: ["R1"],
+        insertDate: new Date(),
+        items_nb: 1
+      }
+    ]);
+
+    await triggerPendingNotifications(
+      makeSession(await User.findById(user._id))
+    );
+
+    expect(callRefSpy).toHaveBeenCalledTimes(1);
   });
 
   it("logs when a ref fetch returns nothing", async () => {

--- a/tests/44.jorfSearchFromDate.test.ts
+++ b/tests/44.jorfSearchFromDate.test.ts
@@ -1,18 +1,22 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import mongoose from "mongoose";
 
-// Shared spy for the internal jorfAxios instance's `.get`.
-const { getSpy } = vi.hoisted(() => ({ getSpy: vi.fn() }));
+// Shared spies for the internal axios instances. `axios.create()` is stubbed to
+// hand the same object to every module, so the URL tells the callers apart.
+const { getSpy, postSpy } = vi.hoisted(() => ({
+  getSpy: vi.fn(),
+  postSpy: vi.fn()
+}));
 
-// Mock axios so `axios.create()` returns an object whose `.get` we control.
-// Keep the real `isAxiosError` so shouldRetry keeps working.
+// Mock axios so `axios.create()` returns an object whose `.get`/`.post` we
+// control. Keep the real `isAxiosError` so shouldRetry keeps working.
 vi.mock("axios", async (importActual) => {
   const actual = await importActual<typeof import("axios")>();
   return {
     ...actual,
     default: {
       ...(actual.default as object),
-      create: () => ({ get: getSpy })
+      create: () => ({ get: getSpy, post: postSpy })
     },
     isAxiosError: actual.isAxiosError
   };
@@ -27,6 +31,7 @@ vi.mock("../utils/umami.ts", () => ({
 }));
 vi.mock("../utils/debugLogger.ts", () => ({
   logError: vi.fn(() => Promise.resolve()),
+  logWarning: vi.fn(() => Promise.resolve()),
   logErrorForApps: vi.fn(() => Promise.resolve())
 }));
 
@@ -34,6 +39,7 @@ import {
   getJORFRecordsFromDate,
   getJORFMetaRecordsFromDate
 } from "../utils/JORFSearch.utils.ts";
+import { resetLegifranceCaches } from "../utils/legifrance.utils.ts";
 
 // Build a valid raw JORFSearch "people" record for a given source_date (YMD).
 function rawItem(source_date: string) {
@@ -48,18 +54,10 @@ function rawItem(source_date: string) {
   };
 }
 
-// Build a valid raw meta publication for a given date (YMD).
-function rawMeta(date: string) {
-  return {
-    id: "JORFTEXT" + date.replace(/-/g, ""),
-    date,
-    title: "Titre de test",
-    tags: { mesure_nominative: true }
-  };
-}
-
-// Mirrors RETRY_MAX in JORFSearch.utils.ts.
+// Mirrors RETRY_MAX in httpRetry.utils.ts.
 const RETRY_MAX = 5;
+// Mirrors CONSECUTIVE_FAILED_CHUNKS_BEFORE_ABANDON in JORFSearch.utils.ts.
+const FAILED_CHUNKS_BEFORE_ABANDON = 3;
 
 // The day URL for the "records" endpoint is keyed on DD-MM-YYYY.
 function dmy(d: Date): string {
@@ -68,20 +66,68 @@ function dmy(d: Date): string {
   return `${dd}-${mm}-${String(d.getFullYear())}`;
 }
 
-function ymdMinusOneDay(ymd: string): string {
-  const [y, m, d] = ymd.split("-").map((s) => parseInt(s));
-  const dt = new Date(y, m - 1, d);
-  dt.setDate(dt.getDate() - 1);
-  const yy = String(dt.getFullYear());
-  const mm = String(dt.getMonth() + 1).padStart(2, "0");
-  const dd = String(dt.getDate()).padStart(2, "0");
-  return `${yy}-${mm}-${dd}`;
+/** A Legifrance JO summary holding one text per requested day. */
+function jorfContResponse(textId: string) {
+  return {
+    data: {
+      items: [
+        {
+          joCont: {
+            id: "JORFCONT000000000001",
+            structure: {
+              liens: [{ id: textId, titre: "Titre de test" }]
+            }
+          }
+        }
+      ]
+    }
+  };
+}
+
+/**
+ * Routes the Legifrance calls: the token POST, the no-JO day list GET, and the
+ * per-day summary POST. `onSummary` decides what a summary request answers.
+ */
+function mockLegifrance(onSummary: (epochMs: number) => unknown) {
+  postSpy.mockImplementation((url: string, payload: unknown) => {
+    if (url.includes("oauth")) {
+      return Promise.resolve({
+        data: { access_token: "test-token", expires_in: 3600 }
+      });
+    }
+    const { date } = payload as { date: number };
+    return Promise.resolve(onSummary(date));
+  });
+}
+
+function mockDatesWithoutJo(days: number[] = []) {
+  return (url: string) => {
+    if (url.includes("datesWithoutJo")) {
+      return Promise.resolve({ data: { lstDateDisabled: days } });
+    }
+    return Promise.resolve({ data: [], request: {} });
+  };
+}
+
+/** Drives the retry back-off without spending the test's wall-clock on it. */
+async function withFakeTimers<T>(run: () => Promise<T>): Promise<T> {
+  vi.useFakeTimers();
+  try {
+    const pending = run();
+    await vi.runAllTimersAsync();
+    return await pending;
+  } finally {
+    vi.useRealTimers();
+  }
 }
 
 beforeEach(async () => {
   if (!mongoose.connection.db) throw new Error("no db");
   await mongoose.connection.db.dropDatabase();
   vi.clearAllMocks();
+  resetLegifranceCaches();
+  process.env.LEGIFRANCE_CLIENT_ID = "test-id";
+  process.env.LEGIFRANCE_CLIENT_SECRET = "test-secret";
 });
 
 describe("getJORFRecordsFromDate", () => {
@@ -122,17 +168,22 @@ describe("getJORFRecordsFromDate", () => {
     ).toBe(3);
   });
 
-  it("tolerates a day returning a null/string payload and reports it as failed", async () => {
+  it("retries a 2xx carrying a string body before reporting the day failed", async () => {
     getSpy.mockResolvedValue({ data: "error string", request: {} });
 
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    const result = await getJORFRecordsFromDate(new Date(today), ["Telegram"]);
+
+    const result = await withFakeTimers(() =>
+      getJORFRecordsFromDate(new Date(today), ["Telegram"])
+    );
 
     expect(result.items).toEqual([]);
     expect(result.requestedDays).toBe(1);
     expect(result.failedDates).toHaveLength(1);
-    expect(getSpy).toHaveBeenCalledTimes(1);
+    // An HTML login or overload page is transient, so it burns the retries
+    // rather than being read as "this day holds no records".
+    expect(getSpy).toHaveBeenCalledTimes(RETRY_MAX + 1);
   });
 
   it("keeps the days that succeeded when another day fails", async () => {
@@ -151,14 +202,40 @@ describe("getJORFRecordsFromDate", () => {
       return Promise.resolve({ data: [rawItem(ymd)], request: {} });
     });
 
-    const result = await getJORFRecordsFromDate(startDate, ["Telegram"]);
+    const result = await withFakeTimers(() =>
+      getJORFRecordsFromDate(startDate, ["Telegram"])
+    );
 
     expect(result.items).toHaveLength(1);
     expect(result.requestedDays).toBe(2);
     expect(result.failedDates).toHaveLength(1);
   });
 
-  it("stops requesting further days once JORFSearch is unreachable", async () => {
+  it("keeps requesting days after a single failed day", async () => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const startDate = new Date(today);
+    startDate.setDate(today.getDate() - 2); // 3-day range, newest first
+
+    const todayDMY = dmy(today);
+    getSpy.mockImplementation((url: string) => {
+      const m = /(\d{2})-(\d{2})-(\d{4})/.exec(url);
+      // Only the newest day fails; the two older ones must still be requested.
+      if (m?.[0] === todayDMY)
+        return Promise.resolve({ data: "error string", request: {} });
+      const ymd = `${m?.[3] ?? "2024"}-${m?.[2] ?? "01"}-${m?.[1] ?? "01"}`;
+      return Promise.resolve({ data: [rawItem(ymd)], request: {} });
+    });
+
+    const result = await withFakeTimers(() =>
+      getJORFRecordsFromDate(startDate, ["Telegram"])
+    );
+
+    expect(result.failedDates).toHaveLength(1);
+    expect(result.items).toHaveLength(2);
+  });
+
+  it("stops requesting further days once the source stays unreachable", async () => {
     getSpy.mockRejectedValue(
       Object.assign(new Error("connect ECONNREFUSED"), {
         isAxiosError: true,
@@ -169,23 +246,19 @@ describe("getJORFRecordsFromDate", () => {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     const startDate = new Date(today);
-    startDate.setDate(today.getDate() - 3); // 4-day range
+    startDate.setDate(today.getDate() - 5); // 6-day range
 
-    // Fake timers so the retry back-off does not cost the test its wall-clock.
-    vi.useFakeTimers();
-    let result;
-    try {
-      const pending = getJORFRecordsFromDate(startDate, ["Telegram"]);
-      await vi.runAllTimersAsync();
-      result = await pending;
-    } finally {
-      vi.useRealTimers();
-    }
+    const result = await withFakeTimers(() =>
+      getJORFRecordsFromDate(startDate, ["Telegram"])
+    );
 
     expect(result.items).toEqual([]);
-    // Every day is reported missing, but only the first one burned its retries.
-    expect(result.failedDates).toHaveLength(4);
-    expect(getSpy).toHaveBeenCalledTimes(RETRY_MAX + 1);
+    // Every day is reported missing, but only the days probed before the
+    // breaker tripped burned their retries.
+    expect(result.failedDates).toHaveLength(6);
+    expect(getSpy).toHaveBeenCalledTimes(
+      FAILED_CHUNKS_BEFORE_ABANDON * (RETRY_MAX + 1)
+    );
   });
 
   it("does not mutate the caller's startDate", async () => {
@@ -203,26 +276,21 @@ describe("getJORFRecordsFromDate", () => {
 
 describe("getJORFMetaRecordsFromDate", () => {
   it("aggregates meta publications across a multi-day range and persists them", async () => {
-    getSpy.mockImplementation((url: string) => {
-      // meta URL: .../meta/search?date=YYYY-MM-DD
-      const m = /date=(\d{4}-\d{2}-\d{2})/.exec(url);
-      const queryDate = m ? m[1] : "2024-01-02";
-      // callJORFSearchMetaDay filters by (queryDate - 1 day)
-      const prev = ymdMinusOneDay(queryDate);
-      return Promise.resolve({ data: [rawMeta(prev)], request: {} });
-    });
+    getSpy.mockImplementation(mockDatesWithoutJo());
+    mockLegifrance((epochMs) => jorfContResponse("JORFTEXT" + String(epochMs)));
 
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     const startDate = new Date(today);
     startDate.setDate(today.getDate() - 2); // 3 chunks of size 1
 
-    const { items: results } = await getJORFMetaRecordsFromDate(startDate, [
-      "Telegram"
-    ]);
+    const { items: results, failedDates } = await getJORFMetaRecordsFromDate(
+      startDate,
+      ["Telegram"]
+    );
 
+    expect(failedDates).toEqual([]);
     expect(results).toHaveLength(3);
-    expect(getSpy).toHaveBeenCalledTimes(3);
     // sorted ascending by date
     for (let i = 1; i < results.length; i++) {
       expect(new Date(results[i].date).getTime()).toBeGreaterThanOrEqual(
@@ -241,13 +309,16 @@ describe("getJORFMetaRecordsFromDate", () => {
   });
 
   it("reports a failed day instead of throwing", async () => {
-    getSpy.mockResolvedValue({ data: "error string", request: {} });
+    getSpy.mockImplementation(mockDatesWithoutJo());
+    // A summary with no container means the edition could not be established.
+    mockLegifrance(() => ({ data: { items: [] } }));
 
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    const result = await getJORFMetaRecordsFromDate(new Date(today), [
-      "Telegram"
-    ]);
+
+    const result = await withFakeTimers(() =>
+      getJORFMetaRecordsFromDate(new Date(today), ["Telegram"])
+    );
 
     expect(result.items).toEqual([]);
     expect(result.requestedDays).toBe(1);

--- a/tests/52.legifranceMeta.test.ts
+++ b/tests/52.legifranceMeta.test.ts
@@ -1,0 +1,375 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import mongoose from "mongoose";
+
+const { getSpy, postSpy, createConfigs } = vi.hoisted(() => ({
+  getSpy: vi.fn(),
+  postSpy: vi.fn(),
+  createConfigs: [] as Record<string, unknown>[]
+}));
+
+vi.mock("axios", async (importActual) => {
+  const actual = await importActual<typeof import("axios")>();
+  return {
+    ...actual,
+    default: {
+      ...(actual.default as object),
+      create: (config: Record<string, unknown>) => {
+        createConfigs.push(config);
+        return { get: getSpy, post: postSpy };
+      }
+    },
+    isAxiosError: actual.isAxiosError
+  };
+});
+
+const { umamiLogSpy, umamiLogAsyncSpy } = vi.hoisted(() => ({
+  umamiLogSpy: vi.fn(),
+  umamiLogAsyncSpy: vi.fn(() => Promise.resolve())
+}));
+vi.mock("../utils/umami.ts", () => ({
+  default: { log: umamiLogSpy, logAsync: umamiLogAsyncSpy }
+}));
+
+const { logErrorSpy, logWarningSpy, logErrorForAppsSpy } = vi.hoisted(() => ({
+  logErrorSpy: vi.fn(() => Promise.resolve()),
+  logWarningSpy: vi.fn(() => Promise.resolve()),
+  logErrorForAppsSpy: vi.fn(() => Promise.resolve())
+}));
+vi.mock("../utils/debugLogger.ts", () => ({
+  logError: logErrorSpy,
+  logWarning: logWarningSpy,
+  logErrorForApps: logErrorForAppsSpy
+}));
+
+import {
+  fetchLegifranceMetaDay,
+  resetLegifranceCaches
+} from "../utils/legifrance.utils.ts";
+import {
+  callJORFSearchReference,
+  resetMissingReferenceCache
+} from "../utils/JORFSearch.utils.ts";
+import { Publication } from "../models/Publication.ts";
+
+const DAY = new Date(2026, 7, 19); // 19 August 2026, local midnight
+const DAY_YMD = "2026-08-19";
+const DAY_UTC_EPOCH = Date.UTC(2026, 7, 19);
+
+function tokenResponse(expiresIn = 3600) {
+  return { data: { access_token: "test-token", expires_in: expiresIn } };
+}
+
+/** Routes the token POST away from the summary POST. */
+function mockPost(onSummary: () => unknown, expiresIn = 3600) {
+  postSpy.mockImplementation((url: string) => {
+    if (url.includes("oauth")) return Promise.resolve(tokenResponse(expiresIn));
+    return Promise.resolve(onSummary());
+  });
+}
+
+function mockDatesWithoutJo(epochs: number[] = []) {
+  getSpy.mockImplementation((url: string) => {
+    if (url.includes("datesWithoutJo")) {
+      return Promise.resolve({ data: { lstDateDisabled: epochs } });
+    }
+    return Promise.resolve({ data: [], request: {} });
+  });
+}
+
+async function withFakeTimers<T>(run: () => Promise<T>): Promise<T> {
+  vi.useFakeTimers();
+  try {
+    const pending = run();
+    await vi.runAllTimersAsync();
+    return await pending;
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+beforeEach(async () => {
+  if (!mongoose.connection.db) throw new Error("no db");
+  await mongoose.connection.db.dropDatabase();
+  vi.clearAllMocks();
+  resetLegifranceCaches();
+  resetMissingReferenceCache();
+  process.env.LEGIFRANCE_CLIENT_ID = "test-id";
+  process.env.LEGIFRANCE_CLIENT_SECRET = "test-secret";
+});
+
+describe("Legifrance client configuration", () => {
+  it("refuses to follow redirects, so a login bounce cannot pass as data", () => {
+    const legifranceConfig = createConfigs.find((c) => c.maxRedirects === 0);
+    expect(legifranceConfig).toBeDefined();
+    const validateStatus = legifranceConfig?.validateStatus as (
+      s: number
+    ) => boolean;
+    expect(validateStatus(200)).toBe(true);
+    expect(validateStatus(302)).toBe(false);
+  });
+});
+
+describe("fetchLegifranceMetaDay", () => {
+  it("flattens texts from nested summary sections", async () => {
+    mockDatesWithoutJo();
+    mockPost(() => ({
+      data: {
+        items: [
+          {
+            joCont: {
+              id: "JORFCONT000000000001",
+              structure: {
+                liens: [{ id: "JORFTEXT000000000001", titre: "Texte racine" }],
+                tms: [
+                  {
+                    liensTxt: [
+                      { id: "JORFTEXT000000000002", titre: "Texte rubrique" }
+                    ],
+                    tms: [
+                      {
+                        liensTxt: [
+                          {
+                            id: "JORFTEXT000000000003",
+                            titre: "Texte sous-rubrique"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }));
+
+    const result = await fetchLegifranceMetaDay(DAY, ["Telegram"]);
+
+    expect(result?.items.map((i) => i.id)).toEqual([
+      "JORFTEXT000000000001",
+      "JORFTEXT000000000002",
+      "JORFTEXT000000000003"
+    ]);
+    // Every text of the edition carries the day it was published on.
+    expect(result?.items.every((i) => i.date === DAY_YMD)).toBe(true);
+  });
+
+  it("drops texts missing an id or a title and counts them", async () => {
+    mockDatesWithoutJo();
+    mockPost(() => ({
+      data: {
+        items: [
+          {
+            joCont: {
+              structure: {
+                liens: [
+                  { id: "JORFTEXT000000000001", titre: "Complet" },
+                  { id: "JORFTEXT000000000002" },
+                  { titre: "Sans identifiant" }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }));
+
+    const result = await fetchLegifranceMetaDay(DAY, ["Telegram"]);
+
+    expect(result?.stats).toEqual({
+      raw_item_nb: 3,
+      clean_item_nb: 1,
+      dropped_item_nb: 2
+    });
+  });
+
+  it("treats a day Legifrance lists as JO-free as an empty success", async () => {
+    mockDatesWithoutJo([DAY_UTC_EPOCH]);
+    mockPost(() => ({ data: { items: [] } }));
+
+    const result = await fetchLegifranceMetaDay(DAY, ["Telegram"]);
+
+    // An empty success, not a gap: the coverage cursor must be free to advance.
+    expect(result).not.toBeNull();
+    expect(result?.items).toEqual([]);
+    // The summary is never requested for a day that has no JO.
+    const summaryCalls = postSpy.mock.calls.filter(
+      (c) => !String(c[0]).includes("oauth")
+    );
+    expect(summaryCalls).toHaveLength(0);
+  });
+
+  it("reports a gap when a day with a JO returns no container", async () => {
+    mockDatesWithoutJo();
+    mockPost(() => ({ data: { items: [] } }));
+
+    const result = await fetchLegifranceMetaDay(DAY, ["Telegram"]);
+
+    expect(result).toBeNull();
+  });
+
+  it("retries an HTML body served with a 2xx instead of reading it as no data", async () => {
+    mockDatesWithoutJo();
+    mockPost(() => ({ data: "<!DOCTYPE html><html>Sign in</html>" }));
+
+    const result = await withFakeTimers(() =>
+      fetchLegifranceMetaDay(DAY, ["Telegram"])
+    );
+
+    expect(result).toBeNull();
+    const summaryCalls = postSpy.mock.calls.filter(
+      (c) => !String(c[0]).includes("oauth")
+    );
+    expect(summaryCalls).toHaveLength(6); // RETRY_MAX + 1
+    expect(logErrorForAppsSpy).toHaveBeenCalled();
+  });
+
+  it("fails fast when the credentials are missing", async () => {
+    delete process.env.LEGIFRANCE_CLIENT_ID;
+    delete process.env.LEGIFRANCE_CLIENT_SECRET;
+    mockDatesWithoutJo();
+    mockPost(() => ({ data: { items: [] } }));
+
+    const result = await fetchLegifranceMetaDay(DAY, ["Telegram"]);
+
+    expect(result).toBeNull();
+    expect(postSpy).not.toHaveBeenCalled();
+    expect(logErrorForAppsSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Legifrance access token", () => {
+  it("reuses a live token across days", async () => {
+    mockDatesWithoutJo();
+    mockPost(() => ({ data: { items: [] } }));
+
+    await fetchLegifranceMetaDay(DAY, ["Telegram"]);
+    await fetchLegifranceMetaDay(new Date(2026, 7, 18), ["Telegram"]);
+
+    const tokenCalls = postSpy.mock.calls.filter((c) =>
+      String(c[0]).includes("oauth")
+    );
+    expect(tokenCalls).toHaveLength(1);
+  });
+
+  it("renews a token that is about to expire", async () => {
+    mockDatesWithoutJo();
+    // Shorter than the renewal margin, so it is stale on every use.
+    mockPost(() => ({ data: { items: [] } }), 30);
+
+    await fetchLegifranceMetaDay(DAY, ["Telegram"]);
+    await fetchLegifranceMetaDay(new Date(2026, 7, 18), ["Telegram"]);
+
+    const tokenCalls = postSpy.mock.calls.filter((c) =>
+      String(c[0]).includes("oauth")
+    );
+    // Paired with the test above, which pins a live token to a single fetch.
+    expect(tokenCalls.length).toBeGreaterThan(1);
+  });
+});
+
+describe("reference resolution against the JO summary", () => {
+  const REFERENCE = "JORFTEXT000054708929";
+
+  function mockReferenceLookup(sourceDates: string[]) {
+    getSpy.mockImplementation((url: string) => {
+      if (url.includes("datesWithoutJo")) {
+        return Promise.resolve({ data: { lstDateDisabled: [] } });
+      }
+      return Promise.resolve({
+        data: sourceDates.map((source_date) => ({
+          nom: "Dupont",
+          prenom: "Jean",
+          source_id: REFERENCE,
+          source_date,
+          source_name: "JORF",
+          type_ordre: "nomination",
+          organisations: []
+        })),
+        request: {}
+      });
+    });
+  }
+
+  it("stores the JO edition holding the reference", async () => {
+    mockReferenceLookup([DAY_YMD]);
+    mockPost(() => ({
+      data: {
+        items: [
+          {
+            joCont: {
+              structure: { liens: [{ id: REFERENCE, titre: "Décret" }] }
+            }
+          }
+        ]
+      }
+    }));
+
+    await callJORFSearchReference(REFERENCE, "Telegram");
+
+    await vi.waitFor(async () => {
+      expect(await Publication.findOne({ id: REFERENCE })).not.toBeNull();
+    });
+  });
+
+  it("looks up every date a reference was seen on", async () => {
+    // The reference belongs to the older edition only.
+    mockReferenceLookup(["2026-08-19", "2026-08-18"]);
+    postSpy.mockImplementation((url: string, payload: unknown) => {
+      if (url.includes("oauth")) return Promise.resolve(tokenResponse());
+      const { date } = payload as { date: number };
+      const liens =
+        date === Date.UTC(2026, 7, 18)
+          ? [{ id: REFERENCE, titre: "Décret" }]
+          : [{ id: "JORFTEXT000000000999", titre: "Autre texte" }];
+      return Promise.resolve({
+        data: { items: [{ joCont: { structure: { liens } } }] }
+      });
+    });
+
+    await callJORFSearchReference(REFERENCE, "Telegram");
+
+    await vi.waitFor(async () => {
+      expect(await Publication.findOne({ id: REFERENCE })).not.toBeNull();
+    });
+    // Reading only the first date would have missed it entirely.
+    expect(logWarningSpy).not.toHaveBeenCalled();
+  });
+
+  it("warns once and memoises a reference absent from the JO summary", async () => {
+    mockReferenceLookup([DAY_YMD]);
+    mockPost(() => ({
+      data: {
+        items: [
+          {
+            joCont: {
+              structure: {
+                liens: [{ id: "JORFTEXT000000000999", titre: "Autre texte" }]
+              }
+            }
+          }
+        ]
+      }
+    }));
+
+    await callJORFSearchReference(REFERENCE, "Telegram");
+    await vi.waitFor(() => {
+      expect(logWarningSpy).toHaveBeenCalledTimes(1);
+    });
+
+    const summaryCallsAfterFirst = postSpy.mock.calls.filter(
+      (c) => !String(c[0]).includes("oauth")
+    ).length;
+
+    await callJORFSearchReference(REFERENCE, "Telegram");
+    // A bulletin officiel reference is never in the JO summary; re-fetching a
+    // whole day for it on every message is what floods the error log.
+    await vi.waitFor(() => {
+      expect(
+        postSpy.mock.calls.filter((c) => !String(c[0]).includes("oauth")).length
+      ).toBe(summaryCallsAfterFirst);
+    });
+    expect(logWarningSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/53.matrixLogService.test.ts
+++ b/tests/53.matrixLogService.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  configureMatrixLogging,
+  createMatrixLogger,
+  describeMatrixPayload,
+  MAX_PAYLOAD_CHARS,
+  REPEAT_SUMMARY_INTERVAL_MS
+} from "../utils/matrixLogService.ts";
+
+const HTML_502 = [
+  "<!DOCTYPE html>",
+  '<html lang="fr"><head>',
+  "  <title>502</title>",
+  "  <style>body { font-family: 'Inter', sans-serif; }</style>",
+  "</head>",
+  "<body>",
+  '  <div class="error-code">Erreur 502</div>',
+  '  <div class="error-title">Bad Gateway</div>',
+  "</body></html>"
+].join("\n");
+
+const errors: string[] = [];
+const infos: string[] = [];
+const warnings: string[] = [];
+
+const errorLines = () => errors;
+const infoLines = () => infos;
+
+const capture =
+  (into: string[]) =>
+  (...args: unknown[]) => {
+    into.push(args.map((arg) => String(arg)).join(" "));
+  };
+
+beforeEach(() => {
+  errors.length = 0;
+  infos.length = 0;
+  warnings.length = 0;
+  vi.spyOn(console, "error").mockImplementation(capture(errors));
+  vi.spyOn(console, "log").mockImplementation(capture(infos));
+  vi.spyOn(console, "warn").mockImplementation(capture(warnings));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("describeMatrixPayload", () => {
+  it("summarizes an HTML error page instead of printing it", () => {
+    const summary = describeMatrixPayload(HTML_502);
+
+    expect(summary).toContain("HTML body");
+    expect(summary).toContain("502");
+    expect(summary).not.toContain("<style>");
+    expect(summary.length).toBeLessThan(200);
+  });
+
+  it("names the errcode and message of a Matrix error body", () => {
+    const summary = describeMatrixPayload({
+      errcode: "M_UNKNOWN",
+      error: "Unable to introspect the access token"
+    });
+
+    expect(summary).toBe("M_UNKNOWN: Unable to introspect the access token");
+  });
+
+  it("reports the status code of a thrown HTTP response and summarizes its body", () => {
+    const summary = describeMatrixPayload({
+      statusCode: 502,
+      body: HTML_502
+    });
+
+    expect(summary).toContain("HTTP 502");
+    expect(summary).toContain("HTML body");
+    expect(summary).not.toContain("<style>");
+  });
+
+  it("never yields [object Object] for a plain object", () => {
+    const summary = describeMatrixPayload({ next_batch: "s123", rooms: {} });
+
+    expect(summary).not.toContain("[object Object]");
+    expect(summary).toContain("next_batch");
+  });
+
+  it("truncates payloads longer than the cap", () => {
+    const summary = describeMatrixPayload("x".repeat(MAX_PAYLOAD_CHARS * 3));
+
+    expect(summary.length).toBeLessThanOrEqual(MAX_PAYLOAD_CHARS + 20);
+    expect(summary).toContain("truncated");
+  });
+
+  it("keeps an Error readable", () => {
+    const summary = describeMatrixPayload(new Error("read ECONNRESET"));
+
+    expect(summary).toContain("read ECONNRESET");
+  });
+});
+
+describe("createMatrixLogger", () => {
+  it("tags every line with the app label", () => {
+    const logger = createMatrixLogger("Tchap");
+
+    logger.error("MatrixHttpClient", "(REQ-7)", {
+      errcode: "M_NOT_FOUND",
+      error: "Event not found."
+    });
+
+    expect(errorLines()[0]).toContain("[Tchap]");
+    expect(errorLines()[0]).toContain("M_NOT_FOUND: Event not found.");
+  });
+
+  it("attaches the method and path of the request that failed", () => {
+    const logger = createMatrixLogger("Matrix");
+
+    logger.debug(
+      "MatrixHttpClient",
+      "(REQ-4)",
+      "GET https://matrix.example.org/_matrix/client/v3/rooms/!a:b/event/$c"
+    );
+    logger.error("MatrixHttpClient", "(REQ-4)", {
+      errcode: "M_NOT_FOUND",
+      error: "Event not found."
+    });
+
+    const line = errorLines()[0];
+    expect(line).toContain("GET /_matrix/client/v3/rooms/!a:b/event/$c");
+    expect(line).toContain("M_NOT_FOUND");
+  });
+
+  it("does not print request-start debug lines", () => {
+    const logger = createMatrixLogger("Matrix");
+
+    logger.debug("MatrixHttpClient", "(REQ-9)", "GET https://home/_matrix/x");
+
+    expect(infoLines()).toHaveLength(0);
+  });
+
+  it("drops the sync backoff chatter", () => {
+    const logger = createMatrixLogger("Matrix");
+
+    logger.info("MatrixClientLite", "Backing off for 6616.42ms");
+
+    expect(infoLines()).toHaveLength(0);
+  });
+
+  it("drops the sync error line, which carries no usable detail", () => {
+    const logger = createMatrixLogger("Matrix");
+
+    logger.error("MatrixClientLite", "Error handling sync [object Object]");
+
+    expect(errorLines()).toHaveLength(0);
+  });
+
+  it("keeps other MatrixClientLite lines", () => {
+    const logger = createMatrixLogger("Matrix");
+
+    logger.info("MatrixClientLite", "End-to-end encryption enabled");
+
+    expect(infoLines()[0]).toContain("End-to-end encryption enabled");
+  });
+
+  it("prints a repeated failure once, then one summary per interval", () => {
+    let clock = 0;
+    const logger = createMatrixLogger("Tchap", { now: () => clock });
+    const fail = () => {
+      logger.error("MatrixHttpClient", "(REQ-1)", {
+        errcode: "M_UNKNOWN",
+        error: "Unable to introspect the access token"
+      });
+    };
+
+    const repeats = REPEAT_SUMMARY_INTERVAL_MS / 10_000;
+    fail();
+    for (let i = 0; i < repeats; i++) {
+      clock += 10_000;
+      fail();
+    }
+
+    const lines = errorLines();
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain("Unable to introspect the access token");
+    expect(lines[1]).toContain(`${String(repeats + 1)} times`);
+    expect(lines[1]).toContain("Unable to introspect the access token");
+  });
+
+  it("prints a different failure immediately", () => {
+    const logger = createMatrixLogger("Tchap", { now: () => 0 });
+
+    logger.error("MatrixHttpClient", "(REQ-1)", { errcode: "M_UNKNOWN" });
+    logger.error("MatrixHttpClient", "(REQ-2)", { errcode: "M_FORBIDDEN" });
+
+    expect(errorLines()).toHaveLength(2);
+  });
+
+  it("routes warnings to console.warn", () => {
+    const logger = createMatrixLogger("Matrix");
+
+    logger.warn("CryptoClient", "Unknown device");
+
+    expect(warnings).toHaveLength(1);
+  });
+});
+
+describe("configureMatrixLogging", () => {
+  it("enables the debug level so request paths can be correlated", async () => {
+    const { LogService, LogLevel } = await import("matrix-bot-sdk");
+
+    configureMatrixLogging("Matrix");
+
+    expect(LogService.level.includes(LogLevel.DEBUG)).toBe(true);
+  });
+});

--- a/tests/54.matrixSyncHealth.test.ts
+++ b/tests/54.matrixSyncHealth.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { logErrorSpy, logWarningSpy } = vi.hoisted(() => ({
+  logErrorSpy: vi.fn(() => Promise.resolve()),
+  logWarningSpy: vi.fn(() => Promise.resolve())
+}));
+
+vi.mock("../utils/debugLogger.ts", () => ({
+  logError: logErrorSpy,
+  logWarning: logWarningSpy
+}));
+
+const {
+  attachSyncHealth,
+  createSyncHealth,
+  SYNC_ALERT_AFTER_FAILURES,
+  SYNC_ALERT_AFTER_MS,
+  SYNC_REALERT_COOLDOWN_MS
+} = await import("../utils/matrixSyncHealth.ts");
+
+const tokenError = () => ({
+  errcode: "M_UNKNOWN",
+  error: "Unable to introspect the access token"
+});
+
+const alertTexts = () =>
+  logErrorSpy.mock.calls.map((call) => (call as unknown as string[]).join(" "));
+
+let clock: number;
+
+const healthWithClock = () => createSyncHealth("Tchap", { now: () => clock });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clock = 0;
+});
+
+describe("sync health alerting", () => {
+  it("stays quiet while failures are below the threshold", async () => {
+    const health = healthWithClock();
+
+    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES - 1; i++) {
+      clock += 1000;
+      await health.recordFailure(tokenError());
+    }
+
+    expect(logErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("alerts once when the failures pile up, naming the errcode", async () => {
+    const health = healthWithClock();
+
+    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES + 5; i++) {
+      clock += 1000;
+      await health.recordFailure(tokenError());
+    }
+
+    expect(logErrorSpy).toHaveBeenCalledTimes(1);
+    const alert = alertTexts()[0];
+    expect(alert).toContain("Tchap");
+    expect(alert).toContain("Unable to introspect the access token");
+    expect(alert).not.toContain("[object Object]");
+  });
+
+  it("alerts on a short but long-lasting outage", async () => {
+    const health = healthWithClock();
+
+    await health.recordFailure(tokenError());
+    clock += SYNC_ALERT_AFTER_MS + 1;
+    await health.recordFailure(tokenError());
+
+    expect(logErrorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-alerts only once the cooldown has elapsed", async () => {
+    const health = healthWithClock();
+
+    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
+      clock += 1000;
+      await health.recordFailure(tokenError());
+    }
+    expect(logErrorSpy).toHaveBeenCalledTimes(1);
+
+    clock += SYNC_REALERT_COOLDOWN_MS - 1;
+    await health.recordFailure(tokenError());
+    expect(logErrorSpy).toHaveBeenCalledTimes(1);
+
+    clock += 2;
+    await health.recordFailure(tokenError());
+    expect(logErrorSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports recovery with the outage duration once sync succeeds", async () => {
+    const health = healthWithClock();
+
+    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
+      clock += 60_000;
+      await health.recordFailure(tokenError());
+    }
+    await health.recordSuccess();
+
+    expect(logWarningSpy).toHaveBeenCalledTimes(1);
+    const recovery = (logWarningSpy.mock.calls[0] as unknown as string[]).join(
+      " "
+    );
+    expect(recovery).toContain("recovered");
+    expect(recovery).toMatch(/\dm/);
+  });
+
+  it("says nothing on a success that follows no alert", async () => {
+    const health = healthWithClock();
+
+    await health.recordFailure(tokenError());
+    await health.recordSuccess();
+
+    expect(logWarningSpy).not.toHaveBeenCalled();
+    expect(logErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("starts a fresh streak after a recovery", async () => {
+    const health = healthWithClock();
+
+    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
+      clock += 1000;
+      await health.recordFailure(tokenError());
+    }
+    await health.recordSuccess();
+    clock += 1000;
+    await health.recordFailure(tokenError());
+
+    expect(logErrorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a node network error readable", async () => {
+    const health = healthWithClock();
+
+    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
+      clock += 1000;
+      await health.recordFailure(new Error("read ECONNRESET"));
+    }
+
+    expect(alertTexts()[0]).toContain("read ECONNRESET");
+  });
+});
+
+describe("attachSyncHealth", () => {
+  const fakeClient = (doSync: (token: string) => Promise<unknown>) => ({
+    doSync
+  });
+
+  it("passes the sync response through untouched", async () => {
+    const client = fakeClient(() => Promise.resolve({ next_batch: "s42" }));
+    attachSyncHealth(client, healthWithClock());
+
+    await expect(client.doSync("s41")).resolves.toEqual({ next_batch: "s42" });
+  });
+
+  it("rethrows a sync failure so the SDK keeps its own backoff", async () => {
+    const failure = new Error("read ECONNRESET");
+    const client = fakeClient(() => Promise.reject(failure));
+    attachSyncHealth(client, healthWithClock());
+
+    await expect(client.doSync("s41")).rejects.toBe(failure);
+  });
+
+  it("alerts once the failed syncs pile up", async () => {
+    const client = fakeClient(() => Promise.reject(new Error("boom")));
+    attachSyncHealth(client, healthWithClock());
+
+    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
+      clock += 1000;
+      await expect(client.doSync("s41")).rejects.toThrow("boom");
+    }
+
+    expect(logErrorSpy).toHaveBeenCalledTimes(1);
+    expect(alertTexts()[0]).toContain("boom");
+  });
+
+  it("reports the recovery when a later sync succeeds", async () => {
+    let fail = true;
+    const client = fakeClient(() =>
+      fail ? Promise.reject(new Error("boom")) : Promise.resolve({})
+    );
+    attachSyncHealth(client, healthWithClock());
+
+    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
+      clock += 1000;
+      await expect(client.doSync("s41")).rejects.toThrow("boom");
+    }
+    fail = false;
+    await client.doSync("s41");
+
+    expect(logWarningSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/55.envUtils.test.ts
+++ b/tests/55.envUtils.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { parseBooleanEnv } from "../utils/env.utils.ts";
+
+describe("parseBooleanEnv", () => {
+  it("falls back when the variable is unset", () => {
+    expect(parseBooleanEnv(undefined, true)).toBe(true);
+    expect(parseBooleanEnv(undefined, false)).toBe(false);
+  });
+
+  it("falls back on an empty or whitespace value", () => {
+    expect(parseBooleanEnv("", true)).toBe(true);
+    expect(parseBooleanEnv("   ", true)).toBe(true);
+  });
+
+  it("reads the usual falsy spellings as false", () => {
+    for (const value of ["false", "FALSE", "False", "0", "no", "off"]) {
+      expect(parseBooleanEnv(value, true)).toBe(false);
+    }
+  });
+
+  it("reads the usual truthy spellings as true", () => {
+    for (const value of ["true", "TRUE", "1", "yes", "on"]) {
+      expect(parseBooleanEnv(value, false)).toBe(true);
+    }
+  });
+
+  it("falls back on a value it cannot interpret", () => {
+    expect(parseBooleanEnv("maybe", true)).toBe(true);
+    expect(parseBooleanEnv("maybe", false)).toBe(false);
+  });
+});
+
+describe("missingEnvVars", () => {
+  it("names the variables that are unset or empty", async () => {
+    const { missingEnvVars } = await import("../utils/env.utils.ts");
+
+    expect(
+      missingEnvVars({ A: "set", B: undefined, C: "  ", D: "also set" })
+    ).toEqual(["B", "C"]);
+  });
+
+  it("returns nothing when every variable is set", async () => {
+    const { missingEnvVars } = await import("../utils/env.utils.ts");
+
+    expect(missingEnvVars({ A: "x", B: "y" })).toEqual([]);
+  });
+});

--- a/tests/sanitizeSecrets.test.ts
+++ b/tests/sanitizeSecrets.test.ts
@@ -73,6 +73,24 @@ describe("sanitizeSecrets", () => {
     expect(result).toBe("value=<LONG_SECRET>");
   });
 
+  it("leaves the value of a known non-secret variable alone", () => {
+    process.env.NODE_ENV = "production";
+    const result = sanitizeSecrets("Bot started in production mode");
+    expect(result).toBe("Bot started in production mode");
+  });
+
+  it("leaves npm runner variables alone", () => {
+    process.env.npm_lifecycle_event = "start-mx:prod";
+    const result = sanitizeSecrets("Ran start-mx:prod");
+    expect(result).toBe("Ran start-mx:prod");
+  });
+
+  it("still redacts an unrecognized variable, so a new secret is not leaked", () => {
+    process.env.SOME_NEW_VAR = "unlisted-value-1234";
+    const result = sanitizeSecrets("Saw unlisted-value-1234 here");
+    expect(result).toBe("Saw <SOME_NEW_VAR> here");
+  });
+
   it("returns the input unchanged when process.env has no qualifying values", () => {
     // Replace all env vars with values >= 8 chars with short placeholders
     for (const key of Object.keys(process.env)) {

--- a/utils/JORFSearch.utils.ts
+++ b/utils/JORFSearch.utils.ts
@@ -6,34 +6,38 @@ import {
   mergeJORFSearchItemCleaningStats
 } from "../entities/JORFSearchResponse.ts";
 import { MessageApp, WikidataId } from "../types.ts";
-import axios, {
-  AxiosResponse,
-  InternalAxiosRequestConfig,
-  isAxiosError
-} from "axios";
+import axios, { AxiosResponse, InternalAxiosRequestConfig } from "axios";
 import umami from "./umami.ts";
 import {
-  cleanJORFPublication,
   JORFSearchPublication,
-  JORFSearchResponseMeta,
   saveMetaPublications
 } from "../entities/JORFSearchResponseMeta.ts";
 import { FunctionTags } from "../entities/FunctionTags.ts";
 import { dateToString, JORFtoDate } from "./date.utils.ts";
-import { logError, logErrorForApps } from "./debugLogger.ts";
+import { logError, logErrorForApps, logWarning } from "./debugLogger.ts";
 import { IPublication, Publication } from "../models/Publication.ts";
+import {
+  assertJsonPayload,
+  REQUEST_TIMEOUT_MS,
+  RETRY_MAX,
+  shouldRetry,
+  waitBeforeRetry
+} from "./httpRetry.utils.ts";
+import { fetchLegifranceMetaDay } from "./legifrance.utils.ts";
 
 // Per Wikimedia policy, provide a descriptive agent with contact info.
 const USER_AGENT = "JOEL/1.0 (contact@joel-officiel.fr)";
 
-const RETRY_MAX = 5;
-const BASE_RETRY_DELAY_MS = 1000;
 const JORFSEARCH_CALLS_CONCURRENCY = 1;
-// Prevent individual HTTP requests from hanging indefinitely.
-// With RETRY_MAX=5 the worst-case wall-time per call-site is:
-//   (RETRY_MAX+1) × REQUEST_TIMEOUT_MS + Σ(1..RETRY_MAX)×BASE_RETRY_DELAY_MS
-//   = 6 × 10 000 + 15 000 = 75 000 ms  (< Telegraf's 90 s handler timeout)
-const REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Consecutive fully-failed chunks before the remaining days of a range are
+ * abandoned. One failed day is a routine hiccup, and with a chunk of
+ * {@link JORFSEARCH_CALLS_CONCURRENCY} day it must not condemn a whole
+ * backfill; a run of them means the source is down and each further day would
+ * burn `RETRY_MAX + 1` attempts against it for nothing.
+ */
+const CONSECUTIVE_FAILED_CHUNKS_BEFORE_ABANDON = 3;
 
 const jorfAxios = axios.create({
   timeout: REQUEST_TIMEOUT_MS,
@@ -46,12 +50,6 @@ interface CustomInternalAxiosRequestConfig extends InternalAxiosRequestConfig {
     responseUrl?: string;
   };
   responseURL?: string;
-}
-
-function shouldRetry(e: unknown): boolean {
-  if (!isAxiosError(e)) return false;
-  const s = e.response?.status;
-  return !(s && s >= 400 && s < 500 && s !== 408 && s !== 429);
 }
 
 function logJORFSearchError(
@@ -130,9 +128,7 @@ export async function callJORFSearchPeople(
   } catch (error) {
     if (shouldRetry(error)) {
       if (retryNumber < RETRY_MAX) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, BASE_RETRY_DELAY_MS * (retryNumber + 1))
-        );
+        await waitBeforeRetry(retryNumber);
         return await callJORFSearchPeople(
           peopleName,
           messageApp,
@@ -176,12 +172,8 @@ async function callJORFSearchDay(
         )
       )
       .then((res) => {
-        if (res.data === null || typeof res.data === "string") {
-          logJORFSearchError("date");
-          console.log("JORFSearch request for date returned null");
-          return null;
-        }
-        const rawItems = res.data.filter((m) => m.source_date === dateYMD);
+        const data = assertJsonPayload(res.data, "JORFSearch (day records)");
+        const rawItems = data.filter((m) => m.source_date === dateYMD);
         const cleanedItems = cleanJORFItems(rawItems);
         return {
           items: cleanedItems.cleanItems,
@@ -191,9 +183,7 @@ async function callJORFSearchDay(
   } catch (error) {
     if (shouldRetry(error)) {
       if (retryNumber < RETRY_MAX) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, BASE_RETRY_DELAY_MS * (retryNumber + 1))
-        );
+        await waitBeforeRetry(retryNumber);
         return await callJORFSearchDay(day, messageApps, retryNumber + 1);
       } else {
         logJORFSearchError("date");
@@ -244,10 +234,12 @@ function buildDayRange(startDate: Date): Date[] {
  * Walks `days` in chunks of {@link JORFSEARCH_CALLS_CONCURRENCY}, recording the
  * days that came back empty-handed.
  *
- * Once a whole chunk fails, JORFSearch is treated as down and the remaining days
- * are marked failed without being requested: each day already burns
- * `RETRY_MAX + 1` attempts, so a multi-day backfill against a dead host would
- * otherwise spend minutes hammering it before reaching the notification stage.
+ * After {@link CONSECUTIVE_FAILED_CHUNKS_BEFORE_ABANDON} chunks fail back to
+ * back, the source is treated as down and the remaining days are marked failed
+ * without being requested: each day already burns `RETRY_MAX + 1` attempts, so
+ * a multi-day backfill against a dead host would otherwise spend minutes
+ * hammering it before reaching the notification stage. Isolated failures do not
+ * trip it, so one bad day no longer condemns the days behind it.
  */
 async function fetchDayRange<T>(
   days: Date[],
@@ -255,6 +247,7 @@ async function fetchDayRange<T>(
 ): Promise<{ results: T[]; failedDates: string[] }> {
   const results: T[] = [];
   const failedDates: string[] = [];
+  let consecutiveFailedChunks = 0;
 
   const limit = JORFSEARCH_CALLS_CONCURRENCY;
   for (let i = 0; i < days.length; i += limit) {
@@ -267,6 +260,12 @@ async function fetchDayRange<T>(
     });
 
     if (subResults.every((result) => result == null)) {
+      consecutiveFailedChunks += 1;
+    } else {
+      consecutiveFailedChunks = 0;
+    }
+
+    if (consecutiveFailedChunks >= CONSECUTIVE_FAILED_CHUNKS_BEFORE_ABANDON) {
       for (const day of days.slice(i + limit)) {
         failedDates.push(dateToString(day, "YMD"));
       }
@@ -316,95 +315,14 @@ export async function getJORFRecordsFromDate(
   };
 }
 
-export interface JORFSearchMetaDayResult {
-  items: JORFSearchPublication[];
-  stats: {
-    raw_item_nb: number;
-    clean_item_nb: number;
-    dropped_item_nb: number;
-  };
-}
-
-export async function callJORFSearchMetaDay(
-  day: Date,
-  messageApps: MessageApp[],
-  retryNumber = 0,
-  saveToInternalDb = true
-): Promise<JORFSearchMetaDayResult | null> {
-  try {
-    const dateYMD = dateToString(day, "YMD");
-
-    const previousDay = new Date(day);
-    // subtract one day
-    previousDay.setDate(previousDay.getDate() - 1);
-    const previousDayYMD = dateToString(previousDay, "YMD");
-
-    return await jorfAxios
-      .get<JORFSearchResponseMeta>(
-        encodeURI(
-          `https://jorfsearch.steinertriples.ch/meta/search?date=${dateYMD}`
-        )
-      )
-      .then((res) => {
-        if (res.data === null || typeof res.data === "string") {
-          logJORFSearchError("meta");
-          console.log("JORFSearch request for meta returned null");
-          return null;
-        }
-        const rawItems = res.data.filter((m) => m.date === previousDayYMD);
-        const cleanedItems = cleanJORFPublication(rawItems);
-
-        if (saveToInternalDb) {
-          void saveMetaPublications(cleanedItems, messageApps);
-        }
-        return {
-          items: cleanedItems,
-          stats: {
-            raw_item_nb: rawItems.length,
-            clean_item_nb: cleanedItems.length,
-            dropped_item_nb: rawItems.length - cleanedItems.length
-          }
-        };
-      });
-  } catch (error) {
-    if (shouldRetry(error)) {
-      if (retryNumber < RETRY_MAX) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, BASE_RETRY_DELAY_MS * (retryNumber + 1))
-        );
-        return await callJORFSearchMetaDay(
-          day,
-          messageApps,
-          retryNumber + 1,
-          saveToInternalDb
-        );
-      }
-      logJORFSearchError("meta");
-      await logErrorForApps(
-        messageApps,
-        `JORFSearch request for meta aborted after ${String(RETRY_MAX)} tries`,
-        error
-      );
-    } else {
-      await logErrorForApps(
-        messageApps,
-        "Error in callJORFSearchMetaDay",
-        error
-      );
-    }
-  }
-  return null;
-}
-
 export async function getJORFMetaRecordsFromDate(
   startDate: Date,
   messageApps: MessageApp[]
 ): Promise<JORFRangeResult<JORFSearchPublication>> {
   const days = buildDayRange(startDate);
 
-  const { results, failedDates } = await fetchDayRange(
-    days,
-    (day) => callJORFSearchMetaDay(day, messageApps, 0, false) // saved to dB in batch below
+  const { results, failedDates } = await fetchDayRange(days, (day) =>
+    fetchLegifranceMetaDay(day, messageApps)
   );
 
   const allItems: JORFSearchPublication[] = [];
@@ -455,12 +373,8 @@ export async function callJORFSearchTag(
         getJORFSearchLinkFunctionTag(tag, true, tagValue)
       )
       .then((res) => {
-        if (res.data === null || typeof res.data === "string") {
-          logJORFSearchError("function_tag");
-          console.log("JORFSearch request for tag returned null");
-          return null;
-        }
-        const cleanedItems = cleanJORFItems(res.data);
+        const data = assertJsonPayload(res.data, "JORFSearch (function tag)");
+        const cleanedItems = cleanJORFItems(data);
         umami.log({
           event: "/jorfsearch-request-tag",
           messageApp,
@@ -471,9 +385,7 @@ export async function callJORFSearchTag(
   } catch (error) {
     if (shouldRetry(error)) {
       if (retryNumber < RETRY_MAX) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, BASE_RETRY_DELAY_MS * (retryNumber + 1))
-        );
+        await waitBeforeRetry(retryNumber);
         return await callJORFSearchTag(
           tag,
           messageApp,
@@ -508,12 +420,8 @@ export async function callJORFSearchOrganisation(
         )
       )
       .then((res) => {
-        if (res.data === null || typeof res.data === "string") {
-          logJORFSearchError("organisation");
-          console.log("JORFSearch request for organisation returned null");
-          return null;
-        }
-        const cleanedItems = cleanJORFItems(res.data);
+        const data = assertJsonPayload(res.data, "JORFSearch (organisation)");
+        const cleanedItems = cleanJORFItems(data);
         umami.log({
           event: "/jorfsearch-request-organisation",
           messageApp,
@@ -524,9 +432,7 @@ export async function callJORFSearchOrganisation(
   } catch (error) {
     if (shouldRetry(error)) {
       if (retryNumber < RETRY_MAX) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, BASE_RETRY_DELAY_MS * (retryNumber + 1))
-        );
+        await waitBeforeRetry(retryNumber);
         return await callJORFSearchOrganisation(
           wikiId,
           messageApp,
@@ -604,12 +510,8 @@ export async function searchOrganisationWikidataId(
     return await jorfAxios
       .get<{ name: string; id: WikidataId }[] | null>(url)
       .then((res) => {
-        if (res.data === null || typeof res.data === "string") {
-          logJORFSearchError("wikidata");
-          console.log("JORFSearch request for wikidata returned null");
-          return null;
-        }
-        return res.data.map((o) => ({
+        const data = assertJsonPayload(res.data, "JORFSearch (wikidata)");
+        return data.map((o) => ({
           nom: o.name,
           wikidataId: o.id
         }));
@@ -617,9 +519,7 @@ export async function searchOrganisationWikidataId(
   } catch (error) {
     if (shouldRetry(error)) {
       if (retryNumber < RETRY_MAX) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, BASE_RETRY_DELAY_MS * (retryNumber + 1))
-        );
+        await waitBeforeRetry(retryNumber);
         return await searchOrganisationWikidataId(
           org_name,
           messageApp,
@@ -645,9 +545,39 @@ export async function searchOrganisationWikidataId(
   return null;
 }
 
+/**
+ * References that are absent from the JO summary of their own publication day.
+ * Bulletins officiels (BOMI, BOEN, BOSanté and the others) are legitimate
+ * sources that are never published at the JO, so they can never be resolved.
+ * Without this, every message from every user re-fetches the same whole day for
+ * the same doomed reference.
+ */
+const missingReferenceCache = new Map<string, number>();
+const MISSING_REFERENCE_TTL_MS = 60 * 60 * 1000;
+
+/** Test seam: drops the memo of references known to be absent from the JO. */
+export function resetMissingReferenceCache(): void {
+  missingReferenceCache.clear();
+}
+
+function isKnownMissingReference(reference: string): boolean {
+  const seenAt = missingReferenceCache.get(reference);
+  if (seenAt === undefined) return false;
+  if (Date.now() - seenAt < MISSING_REFERENCE_TTL_MS) return true;
+  missingReferenceCache.delete(reference);
+  return false;
+}
+
+/**
+ * Ensures the JO publication carrying `reference` is stored locally, fetching
+ * the summary of each day the reference was seen on until one of them holds it.
+ *
+ * A reference can carry several dates when a document spans more than one JO
+ * edition, and only the day that actually lists it resolves the lookup.
+ */
 async function checkReferenceInDb(
   reference: string,
-  dateYMD: string,
+  dateYMDs: string[],
   messageApp: MessageApp
 ): Promise<void> {
   try {
@@ -656,40 +586,51 @@ async function checkReferenceInDb(
     });
     if (res != null) return;
 
-    const dateSplit = dateYMD.split("-").map((s) => parseInt(s)); // YYYY-MM-DD
-    if (dateSplit.some((s) => isNaN(s))) {
-      await logError(
-        messageApp,
-        `Error parsing date ${dateYMD} in items from reference ${reference}`
-      );
-      return;
-    }
-    // callJORFSearchMetaDay queries the API with the given date but filters by previousDay
-    // So we need to add 1 day to get publications with date === referenceDate
-    // Note: Date constructor handles day overflow correctly (e.g., Jan 32 → Feb 1)
-    const queryDate = new Date(
-      dateSplit[0],
-      dateSplit[1] - 1,
-      dateSplit[2] + 1
+    if (isKnownMissingReference(reference)) return;
+
+    const validDates = dateYMDs.filter(
+      (dateYMD) => !dateYMD.split("-").map(Number).some(isNaN)
     );
-    const publicationItem = await callJORFSearchMetaDay(
-      queryDate,
-      [messageApp],
-      0,
-      false
-    ); // do not save to db yet
-    if (publicationItem == null) {
+    if (validDates.length === 0) {
       await logError(
         messageApp,
-        `No meta publication found for reference ${reference} on date ${dateYMD}`
+        `Error parsing dates ${dateYMDs.join(", ")} in items from reference ${reference}`
       );
       return;
     }
-    await saveMetaPublications(publicationItem.items, [messageApp]); // save to db (if not already saved by a previous reference)
+
+    let anyDayFetched = false;
+    for (const dateYMD of validDates) {
+      const publicationDay = await fetchLegifranceMetaDay(JORFtoDate(dateYMD), [
+        messageApp
+      ]);
+      if (publicationDay == null) continue;
+      anyDayFetched = true;
+
+      // Persist the whole day regardless: the other texts of that edition are
+      // very likely to be looked up next.
+      await saveMetaPublications(publicationDay.items, [messageApp]);
+
+      if (publicationDay.items.some((item) => item.id === reference)) return;
+    }
+
+    if (!anyDayFetched) {
+      await logError(
+        messageApp,
+        `Could not fetch the JO summary for reference ${reference} on ${validDates.join(", ")}`
+      );
+      return;
+    }
+
+    missingReferenceCache.set(reference, Date.now());
+    await logWarning(
+      messageApp,
+      `Reference ${reference} is absent from the JO summary of ${validDates.join(", ")}; it is likely published in a bulletin officiel rather than at the JO`
+    );
   } catch (error) {
     await logError(
       messageApp,
-      `Error in checkReferenceInDb for reference ${reference} on date ${dateYMD}`,
+      `Error in checkReferenceInDb for reference ${reference} on ${dateYMDs.join(", ")}`,
       error
     );
   }
@@ -708,12 +649,8 @@ export async function callJORFSearchReference(
         )
       )
       .then((res) => {
-        if (res.data === null || typeof res.data === "string") {
-          logJORFSearchError("reference");
-          console.log("JORFSearch request for reference returned null");
-          return null;
-        }
-        const cleanedItems = cleanJORFItems(res.data);
+        const data = assertJsonPayload(res.data, "JORFSearch (reference)");
+        const cleanedItems = cleanJORFItems(data);
         umami.log({
           event: "/jorfsearch-request-reference",
           messageApp,
@@ -723,7 +660,7 @@ export async function callJORFSearchReference(
 
         void checkReferenceInDb(
           reference,
-          cleanedItems.cleanItems[0].source_date,
+          [...new Set(cleanedItems.cleanItems.map((i) => i.source_date))],
           messageApp
         ); // check db in the background
         return cleanedItems.cleanItems;
@@ -731,9 +668,7 @@ export async function callJORFSearchReference(
   } catch (error) {
     if (shouldRetry(error)) {
       if (retryNumber < RETRY_MAX) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, BASE_RETRY_DELAY_MS * (retryNumber + 1))
-        );
+        await waitBeforeRetry(retryNumber);
         return await callJORFSearchReference(
           reference,
           messageApp,

--- a/utils/debugLogger.ts
+++ b/utils/debugLogger.ts
@@ -12,6 +12,32 @@ type LogLevel = "warning" | "error";
 const DEBUG_CHAT_ID = process.env.DEBUG_CHAT_ID;
 const TELEGRAM_DEBUG_BOT_TOKEN = process.env.TELEGRAM_DEBUG_BOT_TOKEN;
 
+// Runtime and tooling variables whose values are public words that occur in
+// ordinary log text: substituting them turns "started in production mode" into
+// "started in <NODE_ENV> mode". Everything not listed here is still redacted,
+// so an unrecognized variable is treated as a secret.
+const NON_SECRET_ENV_PATTERNS = [
+  /^NODE_ENV$/,
+  /^NODE_OPTIONS$/,
+  /^NODE_VERSION$/,
+  /^MATRIX_BOT_TYPE$/,
+  /^MATRIX_ENCRYPTION_ENABLED$/,
+  /^TZ$/,
+  /^LANG$/,
+  /^PWD$/,
+  /^HOME$/,
+  /^PATH$/,
+  /^SHELL$/,
+  /^TERM$/,
+  /^HOSTNAME$/,
+  /^npm_/,
+  /^VITEST/,
+  /^CI$/
+];
+
+const isNonSecretEnvKey = (key: string): boolean =>
+  NON_SECRET_ENV_PATTERNS.some((pattern) => pattern.test(key));
+
 /**
  * Replaces all `process.env` values (with at least 8 characters) found in the
  * given string with their variable name as a placeholder (e.g. `<TELEGRAM_BOT_TOKEN>`).
@@ -21,7 +47,9 @@ export const sanitizeSecrets = (input: string): string => {
   const entries = Object.entries(process.env)
     .filter(
       (entry): entry is [string, string] =>
-        entry[1] != null && entry[1].trim().length >= 8
+        entry[1] != null &&
+        entry[1].trim().length >= 8 &&
+        !isNonSecretEnvKey(entry[0])
     )
     // Sort by value length descending so longer values are replaced first,
     // avoiding partial replacements when one secret is a prefix of another.
@@ -29,6 +57,9 @@ export const sanitizeSecrets = (input: string): string => {
 
   let result = input;
   for (const [key, value] of entries) {
+    // `includes` scans without allocating; the split/join below copies the
+    // whole string, which matters on multi-kB payloads.
+    if (!result.includes(value)) continue;
     result = result.split(value).join(`<${key}>`);
   }
   return result;

--- a/utils/env.utils.ts
+++ b/utils/env.utils.ts
@@ -1,0 +1,36 @@
+const TRUE_VALUES = new Set(["true", "1", "yes", "on"]);
+const FALSE_VALUES = new Set(["false", "0", "no", "off"]);
+
+/**
+ * Reads a boolean environment variable. `Boolean(value)` cannot be used here:
+ * it is true for the strings "false" and "0", so a variable meant to switch a
+ * feature off would silently leave it on.
+ */
+export const parseBooleanEnv = (
+  value: string | undefined,
+  fallback: boolean
+): boolean => {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized == null || normalized.length === 0) return fallback;
+  if (TRUE_VALUES.has(normalized)) return true;
+  if (FALSE_VALUES.has(normalized)) return false;
+  return fallback;
+};
+
+/**
+ * True when a variable is unset or blank. Coolify leaves an unresolved shared
+ * variable as an empty string, which is as unusable as an absent one.
+ */
+export const isBlankEnv = (value: string | undefined): value is undefined =>
+  value == null || value.trim().length === 0;
+
+/**
+ * Names the variables of the given record that are unset or blank, so a bot
+ * that declines to start can say which one is missing.
+ */
+export const missingEnvVars = (
+  vars: Record<string, string | undefined>
+): string[] =>
+  Object.entries(vars)
+    .filter(([, value]) => isBlankEnv(value))
+    .map(([name]) => name);

--- a/utils/httpRetry.utils.ts
+++ b/utils/httpRetry.utils.ts
@@ -1,0 +1,55 @@
+import { isAxiosError } from "axios";
+
+export const RETRY_MAX = 5;
+export const BASE_RETRY_DELAY_MS = 1000;
+
+// Prevent individual HTTP requests from hanging indefinitely.
+// With RETRY_MAX=5 the worst-case wall-time per call-site is:
+//   (RETRY_MAX+1) × REQUEST_TIMEOUT_MS + Σ(1..RETRY_MAX)×BASE_RETRY_DELAY_MS
+//   = 6 × 10 000 + 15 000 = 75 000 ms  (< Telegraf's 90 s handler timeout)
+export const REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * A 2xx response whose body is not the expected JSON payload: an HTML login
+ * page, an overload notice, or a bare `null`. The status line carries no signal
+ * in that case, so the body is the only tell, and the condition is usually
+ * transient on the server side.
+ */
+export class NonJsonResponseError extends Error {
+  constructor(source: string) {
+    super(`${source} answered 2xx with a non-JSON body`);
+    this.name = "NonJsonResponseError";
+  }
+}
+
+/**
+ * Rejects a payload that is not a JSON array or object, so a login page or an
+ * error page served with a 200 is retried instead of being read as "no data".
+ */
+export function assertJsonPayload<T>(
+  data: T,
+  source: string
+): Exclude<T, null | undefined | string> {
+  if (data === null || data === undefined || typeof data === "string") {
+    throw new NonJsonResponseError(source);
+  }
+  return data as Exclude<T, null | undefined | string>;
+}
+
+export function shouldRetry(e: unknown): boolean {
+  if (e instanceof NonJsonResponseError) return true;
+  if (!isAxiosError(e)) return false;
+  const s = e.response?.status;
+  return !(s && s >= 400 && s < 500 && s !== 408 && s !== 429);
+}
+
+/** Linear backoff: 1 s, 2 s, 3 s, ... on successive attempts. */
+export function retryDelayMs(retryNumber: number): number {
+  return BASE_RETRY_DELAY_MS * (retryNumber + 1);
+}
+
+export function waitBeforeRetry(retryNumber: number): Promise<void> {
+  return new Promise((resolve) =>
+    setTimeout(resolve, retryDelayMs(retryNumber))
+  );
+}

--- a/utils/legifrance.utils.ts
+++ b/utils/legifrance.utils.ts
@@ -1,0 +1,313 @@
+import axios from "axios";
+import { MessageApp } from "../types.ts";
+import { dateToString } from "./date.utils.ts";
+import {
+  cleanJORFPublication,
+  JORFSearchPublication
+} from "../entities/JORFSearchResponseMeta.ts";
+import { logErrorForApps } from "./debugLogger.ts";
+import {
+  assertJsonPayload,
+  REQUEST_TIMEOUT_MS,
+  RETRY_MAX,
+  shouldRetry,
+  waitBeforeRetry
+} from "./httpRetry.utils.ts";
+import umami from "./umami.ts";
+
+// Per Wikimedia policy, provide a descriptive agent with contact info.
+const USER_AGENT = "JOEL/1.0 (contact@joel-officiel.fr)";
+
+const TOKEN_URL = "https://oauth.piste.gouv.fr/api/oauth/token";
+const DEFAULT_API_URL =
+  "https://api.piste.gouv.fr/dila/legifrance/lf-engine-app";
+
+/** Renew the token slightly early so an in-flight request cannot outlive it. */
+const TOKEN_EXPIRY_MARGIN_MS = 60_000;
+
+const DATES_WITHOUT_JO_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** The JO summary nests sections a handful of levels deep; the cap is a guard
+ * against a malformed cyclic payload, not a real structural limit. */
+const MAX_SECTION_DEPTH = 16;
+
+/** Containers per page. A single day holds one JO edition, occasionally a
+ * handful of companion editions, so one page always covers a day. */
+const CONTAINER_PAGE_SIZE = 100;
+
+const legifranceAxios = axios.create({
+  timeout: REQUEST_TIMEOUT_MS,
+  headers: { "User-Agent": USER_AGENT },
+  // A redirect means the request was bounced to a login page. Following it
+  // yields an HTML body that parses as a string and reads as "no data", so a
+  // credential problem must surface as an error instead.
+  maxRedirects: 0,
+  validateStatus: (status) => status >= 200 && status < 300
+});
+
+export function getLegifranceApiUrl(): string {
+  return process.env.LEGIFRANCE_API_URL ?? DEFAULT_API_URL;
+}
+
+interface CachedToken {
+  value: string;
+  expiresAt: number;
+}
+
+let cachedToken: CachedToken | null = null;
+let datesWithoutJoCache: { days: Set<string>; fetchedAt: number } | null = null;
+
+/** Test seam: drops the token and the no-JO day list. */
+export function resetLegifranceCaches(): void {
+  cachedToken = null;
+  datesWithoutJoCache = null;
+}
+
+interface TokenResponse {
+  access_token?: string;
+  expires_in?: number;
+}
+
+async function getAccessToken(): Promise<string> {
+  const now = Date.now();
+  if (
+    cachedToken != null &&
+    now < cachedToken.expiresAt - TOKEN_EXPIRY_MARGIN_MS
+  ) {
+    return cachedToken.value;
+  }
+
+  const clientId = process.env.LEGIFRANCE_CLIENT_ID;
+  const clientSecret = process.env.LEGIFRANCE_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      "Legifrance credentials are missing: set LEGIFRANCE_CLIENT_ID and LEGIFRANCE_CLIENT_SECRET"
+    );
+  }
+
+  const body = new URLSearchParams({
+    grant_type: "client_credentials",
+    client_id: clientId,
+    client_secret: clientSecret,
+    scope: "openid"
+  });
+
+  const res = await legifranceAxios.post<TokenResponse>(TOKEN_URL, body, {
+    headers: { "Content-Type": "application/x-www-form-urlencoded" }
+  });
+  const data = assertJsonPayload(res.data, "Legifrance token endpoint");
+
+  if (!data.access_token) {
+    throw new Error("Legifrance token endpoint returned no access_token");
+  }
+
+  // expires_in is in seconds; fall back to a short life so a malformed
+  // response cannot pin a stale token in memory.
+  const lifetimeMs = (data.expires_in ?? 60) * 1000;
+  cachedToken = { value: data.access_token, expiresAt: now + lifetimeMs };
+  return cachedToken.value;
+}
+
+async function legifrancePost<T>(path: string, payload: unknown): Promise<T> {
+  const token = await getAccessToken();
+  const res = await legifranceAxios.post<T>(
+    `${getLegifranceApiUrl()}${path}`,
+    payload,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json"
+      }
+    }
+  );
+  return assertJsonPayload(res.data, `Legifrance ${path}`);
+}
+
+async function legifranceGet<T>(path: string): Promise<T> {
+  const token = await getAccessToken();
+  const res = await legifranceAxios.get<T>(`${getLegifranceApiUrl()}${path}`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  return assertJsonPayload(res.data, `Legifrance ${path}`);
+}
+
+interface DatesWithNoJoResponse {
+  lstDateDisabled?: (string | number)[];
+}
+
+/** Epoch milliseconds read in UTC: the API stamps each day at UTC midnight, so
+ * reading it in server-local time would shift the day west of Greenwich. */
+function epochToYMD(epoch: string | number): string | null {
+  const ms = typeof epoch === "number" ? epoch : Number(epoch);
+  if (!Number.isFinite(ms)) return null;
+  const d = new Date(ms);
+  const year = String(d.getUTCFullYear());
+  const month = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function ymdToUtcEpoch(dateYMD: string): number {
+  const [year, month, day] = dateYMD.split("-").map((s) => parseInt(s));
+  return Date.UTC(year, month - 1, day);
+}
+
+/**
+ * Days on which no Journal officiel was published, per Legifrance. This is what
+ * separates "nothing was published" from "the fetch failed": without it an
+ * empty summary is ambiguous and every Sunday looks like an outage.
+ */
+async function getDaysWithoutJo(): Promise<Set<string>> {
+  const now = Date.now();
+  if (
+    datesWithoutJoCache != null &&
+    now - datesWithoutJoCache.fetchedAt < DATES_WITHOUT_JO_TTL_MS
+  ) {
+    return datesWithoutJoCache.days;
+  }
+
+  const data = await legifranceGet<DatesWithNoJoResponse>(
+    "/misc/datesWithoutJo"
+  );
+  const days = new Set<string>();
+  for (const raw of data.lstDateDisabled ?? []) {
+    const ymd = epochToYMD(raw);
+    if (ymd != null) days.add(ymd);
+  }
+
+  datesWithoutJoCache = { days, fetchedAt: now };
+  return days;
+}
+
+interface LienTxt {
+  id?: string;
+  titre?: string;
+  nature?: string;
+  ministere?: string;
+  autorite?: string;
+}
+
+interface Tms {
+  liensTxt?: LienTxt[];
+  tms?: Tms[];
+}
+
+interface FullConteneur {
+  id?: string;
+  datePubli?: string;
+  num?: string;
+  structure?: {
+    liens?: LienTxt[];
+    tms?: Tms[];
+  };
+}
+
+interface GetJosResponse {
+  items?: { joCont?: FullConteneur }[];
+}
+
+/**
+ * Flattens a JO summary into its text links. Texts hang either directly off the
+ * container or off arbitrarily nested sections (rubriques and sous-rubriques).
+ */
+function collectTextLinks(container: FullConteneur): LienTxt[] {
+  const links: LienTxt[] = [...(container.structure?.liens ?? [])];
+
+  const visitSection = (section: Tms, depth: number): void => {
+    if (depth > MAX_SECTION_DEPTH) return;
+    links.push(...(section.liensTxt ?? []));
+    for (const child of section.tms ?? []) visitSection(child, depth + 1);
+  };
+
+  for (const section of container.structure?.tms ?? [])
+    visitSection(section, 0);
+  return links;
+}
+
+export interface LegifranceMetaDayResult {
+  items: JORFSearchPublication[];
+  stats: {
+    raw_item_nb: number;
+    clean_item_nb: number;
+    dropped_item_nb: number;
+  };
+}
+
+/**
+ * Retrieves every text published in the Journal officiel on `day`.
+ *
+ * Returns `null` when the day could not be established, so callers can hold
+ * their coverage cursor instead of treating the gap as an empty day. A day
+ * Legifrance lists as having no JO is a success with zero items.
+ */
+export async function fetchLegifranceMetaDay(
+  day: Date,
+  messageApps: MessageApp[],
+  retryNumber = 0
+): Promise<LegifranceMetaDayResult | null> {
+  const dateYMD = dateToString(day, "YMD");
+  const emptyResult: LegifranceMetaDayResult = {
+    items: [],
+    stats: { raw_item_nb: 0, clean_item_nb: 0, dropped_item_nb: 0 }
+  };
+
+  try {
+    const daysWithoutJo = await getDaysWithoutJo();
+    if (daysWithoutJo.has(dateYMD)) return emptyResult;
+
+    const response = await legifrancePost<GetJosResponse>("/consult/jorfCont", {
+      // Legifrance dates its consultation requests in epoch milliseconds. Pin
+      // them to UTC midnight so the server-local timezone cannot shift the day.
+      date: ymdToUtcEpoch(dateYMD),
+      pageNumber: 1,
+      pageSize: CONTAINER_PAGE_SIZE
+    });
+
+    const containers = (response.items ?? [])
+      .map((item) => item.joCont)
+      .filter((cont): cont is FullConteneur => cont != null);
+
+    // The day is neither listed as JO-free nor served with a summary: the
+    // edition is not available, which is a gap rather than an empty day.
+    if (containers.length === 0) return null;
+
+    const rawItems = containers.flatMap(collectTextLinks).map((link) => ({
+      id: link.id,
+      date: dateYMD,
+      title: link.titre,
+      ministere: link.ministere,
+      autorite: link.autorite,
+      tags: {}
+    }));
+
+    const cleanedItems = cleanJORFPublication(rawItems);
+
+    return {
+      items: cleanedItems,
+      stats: {
+        raw_item_nb: rawItems.length,
+        clean_item_nb: cleanedItems.length,
+        dropped_item_nb: rawItems.length - cleanedItems.length
+      }
+    };
+  } catch (error) {
+    if (shouldRetry(error) && retryNumber < RETRY_MAX) {
+      await waitBeforeRetry(retryNumber);
+      return await fetchLegifranceMetaDay(day, messageApps, retryNumber + 1);
+    }
+
+    umami.log({
+      event: "/jorfsearch-error",
+      messageApp: messageApps[0],
+      payload: { meta: true }
+    });
+    await logErrorForApps(
+      messageApps,
+      shouldRetry(error)
+        ? `Legifrance request for the JO of ${dateYMD} aborted after ${String(RETRY_MAX)} tries`
+        : `Error fetching the Legifrance JO summary of ${dateYMD}`,
+      error
+    );
+    return null;
+  }
+}

--- a/utils/matrixLogService.ts
+++ b/utils/matrixLogService.ts
@@ -1,0 +1,206 @@
+import { ILogger, LogLevel, LogService } from "matrix-bot-sdk";
+
+/** Longest payload text kept on a single log line. */
+export const MAX_PAYLOAD_CHARS = 2000;
+
+/** A failure repeating within this window is counted, not reprinted. */
+export const REPEAT_SUMMARY_INTERVAL_MS = 5 * 60 * 1000;
+
+/** Number of (REQ-id → method + path) pairs kept for error correlation. */
+const REQUEST_TRAIL_SIZE = 200;
+
+/** The SDK logs its own messages as strings; anything else is a payload. */
+const asText = (value: unknown): string =>
+  typeof value === "string" ? value : "";
+
+const REQUEST_ID_PATTERN = /^\(REQ-(\d+)\)$/;
+const REQUEST_START_PATTERN = /^(GET|POST|PUT|DELETE) (\S+)$/;
+const HTML_PATTERN = /^\s*<(!doctype|html)/i;
+const HTML_TITLE_PATTERN = /<title[^>]*>([^<]*)<\/title>/i;
+
+const truncate = (text: string): string =>
+  text.length > MAX_PAYLOAD_CHARS
+    ? `${text.slice(0, MAX_PAYLOAD_CHARS)}… (truncated)`
+    : text;
+
+const describeHtml = (html: string): string => {
+  const title = HTML_TITLE_PATTERN.exec(html)?.[1].trim();
+  const bytes = Buffer.byteLength(html);
+  return `HTML body (${String(bytes)} bytes)${title != null && title.length > 0 ? `: ${title}` : ""}`;
+};
+
+const hasKey = <K extends string>(
+  value: object,
+  key: K
+): value is Record<K, unknown> => key in value;
+
+/**
+ * Renders anything the SDK hands to its logger as a short, greppable string.
+ * The SDK logs whole response bodies and throws raw HTTP responses, so without
+ * this a single homeserver 502 puts a multi-kB HTML page on stdout.
+ */
+export const describeMatrixPayload = (value: unknown): string => {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (value instanceof Error) return `${value.name}: ${value.message}`;
+  if (typeof value === "string")
+    return HTML_PATTERN.test(value) ? describeHtml(value) : truncate(value);
+  if (typeof value === "number" || typeof value === "boolean")
+    return String(value);
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "symbol") return value.toString();
+  if (typeof value === "function") return `[function ${value.name}]`;
+
+  if (hasKey(value, "errcode")) {
+    const errcode = String(value.errcode);
+    const detail = hasKey(value, "error") ? String(value.error) : undefined;
+    return detail != null ? `${errcode}: ${detail}` : errcode;
+  }
+
+  if (hasKey(value, "statusCode")) {
+    const status = String(value.statusCode);
+    const body = hasKey(value, "body")
+      ? describeMatrixPayload(value.body)
+      : undefined;
+    return body != null ? `HTTP ${status} ${body}` : `HTTP ${status}`;
+  }
+
+  try {
+    return truncate(JSON.stringify(value));
+  } catch {
+    return truncate(Object.prototype.toString.call(value));
+  }
+};
+
+interface MatrixLoggerOptions {
+  now?: () => number;
+}
+
+interface RepeatState {
+  count: number;
+  lastPrintedAt: number;
+}
+
+const formatDurationShort = (ms: number): string => {
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0
+    ? `${String(minutes)}m${String(seconds)}s`
+    : `${String(seconds)}s`;
+};
+
+/**
+ * Builds the logger the matrix-bot-sdk writes through, for one bot app.
+ *
+ * The SDK's default logger prints raw bodies, gives no way to tell a Matrix
+ * line from a Tchap one, and concatenates error objects into the useless
+ * "Error handling sync [object Object]". This logger summarizes payloads, tags
+ * each line with the app, correlates errors with the request that caused them,
+ * and collapses a repeating failure into one line per
+ * {@link REPEAT_SUMMARY_INTERVAL_MS}.
+ */
+export const createMatrixLogger = (
+  appLabel: string,
+  options: MatrixLoggerOptions = {}
+): ILogger => {
+  const now = options.now ?? (() => Date.now());
+  const requestTrail = new Map<string, string>();
+  const repeats = new Map<string, RepeatState>();
+
+  const rememberRequest = (messageOrObject: unknown[]): void => {
+    const requestId = REQUEST_ID_PATTERN.exec(asText(messageOrObject[0]))?.[1];
+    const start = REQUEST_START_PATTERN.exec(asText(messageOrObject[1]));
+    if (requestId == null || start == null) return;
+
+    let path = start[2];
+    try {
+      path = new URL(start[2]).pathname;
+    } catch {
+      // Not an absolute URL: keep whatever the SDK logged.
+    }
+    if (requestTrail.size >= REQUEST_TRAIL_SIZE) {
+      const oldest = requestTrail.keys().next();
+      if (!oldest.done) requestTrail.delete(oldest.value);
+    }
+    requestTrail.set(requestId, `${start[1]} ${path}`);
+  };
+
+  const describeRequest = (messageOrObject: unknown[]): string | undefined => {
+    const requestId = REQUEST_ID_PATTERN.exec(asText(messageOrObject[0]))?.[1];
+    return requestId != null ? requestTrail.get(requestId) : undefined;
+  };
+
+  const buildLine = (module: string, messageOrObject: unknown[]): string =>
+    [
+      `[${appLabel}]`,
+      module,
+      describeRequest(messageOrObject),
+      ...messageOrObject.map(describeMatrixPayload)
+    ]
+      .filter((part): part is string => part != null)
+      .join(" ");
+
+  return {
+    // Request-start lines exist only to correlate later errors: they are kept
+    // in memory, never printed.
+    trace: (module: string, ...messageOrObject: unknown[]) => {
+      if (module === "MatrixHttpClient") rememberRequest(messageOrObject);
+    },
+    debug: (module: string, ...messageOrObject: unknown[]) => {
+      if (module === "MatrixHttpClient") rememberRequest(messageOrObject);
+    },
+    info: (module: string, ...messageOrObject: unknown[]) => {
+      const text = asText(messageOrObject[0]);
+      // One line per sync retry, forever. The outage itself is reported by the
+      // sync health tracker instead.
+      if (module === "MatrixClientLite" && text.startsWith("Backing off for"))
+        return;
+      console.log(buildLine(module, messageOrObject));
+    },
+    warn: (module: string, ...messageOrObject: unknown[]) => {
+      console.warn(buildLine(module, messageOrObject));
+    },
+    error: (module: string, ...messageOrObject: unknown[]) => {
+      const text = asText(messageOrObject[0]);
+      // The SDK concatenates the error object into this message, so it reads
+      // "[object Object]" or repeats a whole HTML page. The MatrixHttpClient
+      // line just above carries the same failure with its errcode.
+      if (
+        module === "MatrixClientLite" &&
+        text.startsWith("Error handling sync")
+      )
+        return;
+
+      const line = buildLine(module, messageOrObject);
+      const signature = `${module} ${messageOrObject.slice(1).map(describeMatrixPayload).join(" ")}`;
+      const at = now();
+      const seen = repeats.get(signature);
+
+      if (seen == null) {
+        repeats.set(signature, { count: 1, lastPrintedAt: at });
+        console.error(line);
+        return;
+      }
+
+      seen.count += 1;
+      if (at - seen.lastPrintedAt < REPEAT_SUMMARY_INTERVAL_MS) return;
+
+      console.error(
+        `${line} (${String(seen.count)} times in ${formatDurationShort(at - seen.lastPrintedAt)})`
+      );
+      seen.count = 0;
+      seen.lastPrintedAt = at;
+    }
+  };
+};
+
+/**
+ * Points the matrix-bot-sdk at {@link createMatrixLogger}. DEBUG is enabled so
+ * the logger sees request-start lines and can name the endpoint behind a failed
+ * request; those lines are swallowed rather than printed.
+ */
+export const configureMatrixLogging = (appLabel: string): void => {
+  LogService.setLogger(createMatrixLogger(appLabel));
+  LogService.setLevel(LogLevel.DEBUG);
+};

--- a/utils/matrixSyncHealth.ts
+++ b/utils/matrixSyncHealth.ts
@@ -1,0 +1,118 @@
+import { MessageApp } from "../types.ts";
+import { logError, logWarning } from "./debugLogger.ts";
+import { describeMatrixPayload } from "./matrixLogService.ts";
+
+/** Consecutive failed syncs that make an outage worth reporting. */
+export const SYNC_ALERT_AFTER_FAILURES = 5;
+
+/** Or, for a slow sync loop, how long the failures may last before reporting. */
+export const SYNC_ALERT_AFTER_MS = 2 * 60 * 1000;
+
+/** Delay before a still-failing sync is reported again. */
+export const SYNC_REALERT_COOLDOWN_MS = 30 * 60 * 1000;
+
+export interface SyncHealth {
+  recordFailure: (error: unknown) => Promise<void>;
+  recordSuccess: () => Promise<void>;
+}
+
+/** The one sync entry point of a matrix-bot-sdk client. */
+export interface SyncingClient {
+  doSync: (token: string) => Promise<unknown>;
+}
+
+interface SyncHealthOptions {
+  now?: () => number;
+}
+
+const formatOutage = (ms: number): string => {
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0
+    ? `${String(minutes)}m${String(seconds)}s`
+    : `${String(seconds)}s`;
+};
+
+/**
+ * Tracks whether the Matrix sync loop is alive.
+ *
+ * The SDK retries a failed sync forever and only writes to its own logger, so
+ * a homeserver outage or a rejected token is otherwise invisible: no alert, no
+ * umami event, while the app keeps reporting a successful start. This turns a
+ * failing streak into a single alert, and reports the recovery.
+ */
+export const createSyncHealth = (
+  messageApp: MessageApp,
+  options: SyncHealthOptions = {}
+): SyncHealth => {
+  const now = options.now ?? (() => Date.now());
+  let failureCount = 0;
+  let firstFailureAt: number | null = null;
+  let lastAlertAt: number | null = null;
+
+  const reset = () => {
+    failureCount = 0;
+    firstFailureAt = null;
+    lastAlertAt = null;
+  };
+
+  return {
+    recordFailure: async (error: unknown) => {
+      const at = now();
+      failureCount += 1;
+      firstFailureAt ??= at;
+
+      const worthReporting =
+        failureCount >= SYNC_ALERT_AFTER_FAILURES ||
+        at - firstFailureAt >= SYNC_ALERT_AFTER_MS;
+      if (!worthReporting) return;
+      if (lastAlertAt != null && at - lastAlertAt < SYNC_REALERT_COOLDOWN_MS)
+        return;
+
+      lastAlertAt = at;
+      await logError(
+        messageApp,
+        `Matrix sync failing for ${formatOutage(at - firstFailureAt)} (${String(failureCount)} attempts)`,
+        describeMatrixPayload(error)
+      );
+    },
+    recordSuccess: async () => {
+      if (lastAlertAt == null) {
+        reset();
+        return;
+      }
+      const outage = now() - (firstFailureAt ?? now());
+      reset();
+      await logWarning(
+        messageApp,
+        `Matrix sync recovered after ${formatOutage(outage)}`
+      );
+    }
+  };
+};
+
+/**
+ * Wraps a client's sync call so each attempt is recorded, then rethrows.
+ *
+ * The sync loop catches everything internally and logs the error through a
+ * string concatenation that renders a Matrix error body as "[object Object]",
+ * so this is the only place the real error is still available.
+ */
+export const attachSyncHealth = (
+  client: SyncingClient,
+  health: SyncHealth
+): void => {
+  const doSync = client.doSync.bind(client);
+
+  client.doSync = async (token: string) => {
+    try {
+      const response = await doSync(token);
+      await health.recordSuccess();
+      return response;
+    } catch (error) {
+      await health.recordFailure(error);
+      throw error;
+    }
+  };
+};


### PR DESCRIPTION
Two independent fixes ride on this branch.

## Matrix/Tchap log noise and blind spots

Prod logs from both Matrix deployments were loud and uninformative: a single homeserver 502 dumped the whole HTML error page to stdout twice, `MatrixClientLite Error handling sync [object Object]` repeated for an hour, and nothing alerted while the homeserver was rejecting the bot token (`M_UNKNOWN: Unable to introspect the access token`) and dropping connections.

Root cause: the project never configured `matrix-bot-sdk`'s `LogService`, so the SDK ran its default `ConsoleLogger` at INFO, which prints raw response bodies (`http.ts`) and string-concatenates error objects into the sync error line (`MatrixClient.ts`). The sync loop also swallows every failure into an infinite 5-15 s retry that no project code could observe, so `logError` never fired: no Telegram alert, no umami event, while the app kept reporting a successful start.

- `utils/matrixLogService.ts` owns the SDK's output: HTML bodies become `HTML body (12483 bytes): 502`, Matrix error bodies become `M_UNKNOWN: Unable to introspect the access token`, thrown HTTP responses become `HTTP 502 …`, every line is tagged with the app so Matrix and Tchap are distinguishable, and payloads are capped at 2 kB.
- Failed requests now name the endpoint behind them. DEBUG is enabled only so the logger can keep a bounded REQ-id → `GET /_matrix/...` trail; those request-start lines are swallowed, not printed. This is what makes the boot-time `REQ-4 M_NOT_FOUND Event not found` diagnosable.
- The retry storm is collapsed: `Backing off for …` is dropped, the detail-free sync error line is dropped, and a repeating failure prints once plus one summary per 5 minutes.
- `utils/matrixSyncHealth.ts` wraps the client's sync call so the real error survives, then alerts once after 5 consecutive failures (or 2 minutes), re-alerts at most every 30 minutes while still failing, and reports the recovery with the outage duration. The SDK's own backoff is untouched: the error is rethrown.

## Startup and logging hygiene

- Missing env now names the variables that are missing, and a blank value (an unresolved Coolify `{{...}}` placeholder resolves to one) counts as missing.
- A failed boot exits instead of falling through: previously it logged, skipped sync and the notification scheduler, and left Mongoose holding the event loop open, so the container looked healthy while sending nothing.
- `matrixApp` calls `logTelegramDebugStatus()` like `telegramApp` does, so unusable debug credentials are visible at boot instead of silently discarding every alert.
- `MATRIX_ENCRYPTION_ENABLED` is parsed as a boolean. `Boolean("false")` is `true`, so the disabled branch was unreachable; `.env.template` also documented a name (`MATRIX_BOT_ENCRYPTION`) that nothing read, and never mentioned `MATRIX_BOT_TYPE`.
- `npm start` was `npm start:prod`, missing `run`, so it failed immediately. `concurrently` now labels each bot (`-n tg,wh,mx`) and takes the container down on a genuine crash (`--kill-others-on-fail`), while the intentional exit-0 "env not set" path still leaves siblings alone.
- `sanitizeSecrets` no longer substitutes known non-secret variables: with `NODE_ENV=production` it rewrote the word "production" in ordinary log text as `<NODE_ENV>`. Unrecognized variables are still redacted, so a new secret is not leaked. It also skips the split/join allocation when the value is absent, which matters now that it runs over multi-kB payloads.

## Meta publications from Legifrance

First day of #334 in production, `errors.log` was dominated by two families: `JORFSearch is unreachable for meta publications: no day of the range could be fetched` four times, once per channel process, and `No meta publication found for reference JORFTEXT... on date 2026-08-19` forty times over sixteen distinct references.

Root cause: JORFSearch's `/meta/search` moved behind Google OAuth. With the app's exact User-Agent it answers

```
HTTP/1.1 302 Found
Location: /auth/google
```

and axios follows the redirect into 906 kB of HTML from `accounts.google.com`, so `typeof res.data === "string"` returned `null` and every meta day counted as failed. No credential for that host exists in the repo or in `.env.template`, so the endpoint had been unreachable from production for every channel, every day.

This is not the small-server overload it looked like. The records endpoint answers in 0.3 to 0.8 s, serves eight concurrent requests without complaint, and supports conditional GETs; no `records` alert appears anywhere in the log. Nor were the references or their dates wrong: all sixteen are present in JORFSearch's still-public day endpoint with `source_date: "2026-08-19"`. The failed range simply left the lookup map empty, and `checkReferenceInDb` then re-hit the same dead endpoint once per reference per user. `No meta publication found` never meant "absent from the JO", it meant "the day fetch failed".

PR #334 did not cause this. It removed the `throw` that used to abort the cycle, which turned a silent total outage into a visible partial degradation. Its own description records that the meta failure had already taken all four platforms down on three cycles the previous week.

### What changed

- `utils/legifrance.utils.ts` sources the JO summary from the DILA API on PISTE: OAuth `client_credentials` with an in-memory token renewed a minute before expiry, one `POST /consult/jorfCont` per day, and a recursive walk of the summary tree, since texts hang either off the container or off arbitrarily nested rubriques. `maxRedirects: 0` with a `validateStatus` that rejects 3xx means a bounce to a login page surfaces as an error instead of passing for an empty day. That is exactly the guard whose absence produced these 44 lines.
- `GET /misc/datesWithoutJo` separates "no JO was published" from "the fetch failed", a distinction the code could not previously make. A JO-free day is a success with zero items, so the coverage cursor stays free to advance; a day that has a JO but returns no container is a genuine gap.
- No schema migration. `Publication` only ever reads `id`, `date`, `title` and the derived normalized-title fields; `tags`, `nor`, `ministere` and `autorite` are consumed nowhere in production. The single field JORFSearch carries that Legifrance does not is `tags`, and it is dead.
- `utils/httpRetry.utils.ts` centralizes the retry policy, and a 2xx carrying a non-JSON body now throws and is retried across every JORFSearch endpoint rather than only meta. An overload or login page served with a 200 used to fail that day permanently without a single retry.
- The range circuit breaker trips after three consecutive failed chunks instead of one. With `JORFSEARCH_CALLS_CONCURRENCY = 1` a chunk is one day, so a single transient timeout condemned the entire backfill and pinned `coverageCursor` near `startDate`, leaving the same records to requalify on every later cycle.
- `checkReferenceInDb` drops the `+1 day` offset, which asked for tomorrow's edition for any same-day reference and so failed daily irrespective of authentication. It now verifies the reference against the fetched summary, walks every distinct `source_date` of the document instead of reading `items[0]` alone, and memoizes misses for an hour. A reference absent from the JO summary is a warning rather than an error: bulletins officiels such as `BOMI`, `BOEN` and `BOSanté` are legitimate sources that are never published at the JO, and re-fetching a whole day for one on every message from every user is what flooded the log.
- `Publication.find({ source_id: ... })` in `triggerPendingNotifications` queried a field the schema does not define; the key is `id`. It always returned `[]` while the pending queue was cleared regardless, so alert-string notifications were never delivered on re-engagement and were lost. This bug is independent of the meta outage and would have survived the migration.
- `fetchRange` now names its source, so a Legifrance fault no longer reports itself as "JORFSearch is unreachable".

`LEGIFRANCE_CLIENT_ID`, `LEGIFRANCE_CLIENT_SECRET` and `LEGIFRANCE_API_URL` are new required configuration. The PISTE application needs one subscription, Legifrance 2.4.2, with its terms accepted.

## Verification

`npm run lint`, `tsc -p tsconfig.build.json`, and `npm test` all pass locally: 59 test files, 849 tests, 90.9% statement coverage. New suites cover the payload summarizer against the actual 502 page from the prod logs, the REQ correlation, the repeat collapsing, the alert thresholds and cooldown, and the recovery report.

The Legifrance path was additionally checked against the live API with production PISTE credentials, on the exact day of the incident: 83 texts returned for 19 August 2026 with none dropped, and all sixteen references from `errors.log` present. Sunday 16 August comes back as a success with zero items rather than as a gap. `tests/52.legifranceMeta.test.ts` covers the nested-summary flattening, the JO-free day, the retry on an HTML body served with a 200, token reuse and renewal, multi-date reference resolution and the negative cache. The `Publication.find` fix is pinned by two tests in `tests/39.triggerPending.test.ts` that were confirmed to fail when the old field name is restored.

