### PR TITLE
fix(matrix): confirm sync recovery before clearing an outage

### DIFF
--- a/tests/54.matrixSyncHealth.test.ts
+++ b/tests/54.matrixSyncHealth.test.ts
@@ -15,7 +15,8 @@ const {
   createSyncHealth,
   SYNC_ALERT_AFTER_FAILURES,
   SYNC_ALERT_AFTER_MS,
-  SYNC_REALERT_COOLDOWN_MS
+  SYNC_REALERT_COOLDOWN_MS,
+  SYNC_RECOVERY_CONFIRM_MS
 } = await import("../utils/matrixSyncHealth.ts");
 
 const tokenError = () => ({
@@ -25,6 +26,11 @@ const tokenError = () => ({
 
 const alertTexts = () =>
   logErrorSpy.mock.calls.map((call) => (call as unknown as string[]).join(" "));
+
+const recoveryTexts = () =>
+  logWarningSpy.mock.calls.map((call) =>
+    (call as unknown as string[]).join(" ")
+  );
 
 let clock: number;
 
@@ -90,7 +96,7 @@ describe("sync health alerting", () => {
     expect(logErrorSpy).toHaveBeenCalledTimes(2);
   });
 
-  it("reports recovery with the outage duration once sync succeeds", async () => {
+  it("reports recovery once syncs have held for the confirmation window", async () => {
     const health = healthWithClock();
 
     for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
@@ -98,13 +104,66 @@ describe("sync health alerting", () => {
       await health.recordFailure(tokenError());
     }
     await health.recordSuccess();
+    expect(logWarningSpy).not.toHaveBeenCalled();
+
+    clock += SYNC_RECOVERY_CONFIRM_MS;
+    await health.recordSuccess();
 
     expect(logWarningSpy).toHaveBeenCalledTimes(1);
-    const recovery = (logWarningSpy.mock.calls[0] as unknown as string[]).join(
-      " "
-    );
-    expect(recovery).toContain("recovered");
-    expect(recovery).toMatch(/\dm/);
+    expect(recoveryTexts()[0]).toContain("recovered");
+  });
+
+  it("measures the outage up to the first success, not the confirmation", async () => {
+    const health = healthWithClock();
+
+    await health.recordFailure(tokenError());
+    clock += 4 * 60_000;
+    await health.recordFailure(tokenError());
+    await health.recordSuccess();
+
+    clock += SYNC_RECOVERY_CONFIRM_MS * 3;
+    await health.recordSuccess();
+
+    expect(recoveryTexts()[0]).toContain("recovered after 4m0s");
+  });
+
+  it("stays on one incident while sync flaps", async () => {
+    const health = healthWithClock();
+
+    // Two flap cycles, kept inside SYNC_REALERT_COOLDOWN_MS so the only thing
+    // that could speak up is the flapping itself.
+    for (let round = 0; round < 2; round++) {
+      for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
+        clock += 30_000;
+        await health.recordFailure(tokenError());
+      }
+      await health.recordSuccess();
+      clock += SYNC_RECOVERY_CONFIRM_MS - 60_000;
+      await health.recordSuccess();
+    }
+
+    expect(logErrorSpy).toHaveBeenCalledTimes(1);
+    expect(logWarningSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps the re-alert cooldown across a brief success", async () => {
+    const health = healthWithClock();
+
+    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
+      clock += 1000;
+      await health.recordFailure(tokenError());
+    }
+    expect(logErrorSpy).toHaveBeenCalledTimes(1);
+    const alertedAt = clock;
+
+    await health.recordSuccess();
+    clock = alertedAt + SYNC_REALERT_COOLDOWN_MS - 1;
+    await health.recordFailure(tokenError());
+    expect(logErrorSpy).toHaveBeenCalledTimes(1);
+
+    clock += 2;
+    await health.recordFailure(tokenError());
+    expect(logErrorSpy).toHaveBeenCalledTimes(2);
   });
 
   it("says nothing on a success that follows no alert", async () => {
@@ -117,7 +176,7 @@ describe("sync health alerting", () => {
     expect(logErrorSpy).not.toHaveBeenCalled();
   });
 
-  it("starts a fresh streak after a recovery", async () => {
+  it("starts a fresh streak after a confirmed recovery", async () => {
     const health = healthWithClock();
 
     for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
@@ -125,10 +184,18 @@ describe("sync health alerting", () => {
       await health.recordFailure(tokenError());
     }
     await health.recordSuccess();
+    clock += SYNC_RECOVERY_CONFIRM_MS;
+    await health.recordSuccess();
+
+    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES - 1; i++) {
+      clock += 1000;
+      await health.recordFailure(tokenError());
+    }
+    expect(logErrorSpy).toHaveBeenCalledTimes(1);
+
     clock += 1000;
     await health.recordFailure(tokenError());
-
-    expect(logErrorSpy).toHaveBeenCalledTimes(1);
+    expect(logErrorSpy).toHaveBeenCalledTimes(2);
   });
 
   it("keeps a node network error readable", async () => {
@@ -176,7 +243,7 @@ describe("attachSyncHealth", () => {
     expect(alertTexts()[0]).toContain("boom");
   });
 
-  it("reports the recovery when a later sync succeeds", async () => {
+  it("reports the recovery once the syncs keep succeeding", async () => {
     let fail = true;
     const client = fakeClient(() =>
       fail ? Promise.reject(new Error("boom")) : Promise.resolve({})
@@ -189,6 +256,8 @@ describe("attachSyncHealth", () => {
     }
     fail = false;
     await client.doSync("s41");
+    clock += SYNC_RECOVERY_CONFIRM_MS;
+    await client.doSync("s42");
 
     expect(logWarningSpy).toHaveBeenCalledTimes(1);
   });

--- a/utils/matrixSyncHealth.ts
+++ b/utils/matrixSyncHealth.ts
@@ -11,6 +11,13 @@ export const SYNC_ALERT_AFTER_MS = 2 * 60 * 1000;
 /** Delay before a still-failing sync is reported again. */
 export const SYNC_REALERT_COOLDOWN_MS = 30 * 60 * 1000;
 
+/**
+ * How long syncs must keep succeeding before the outage is called over.
+ * A flaky homeserver answers one sync then fails the next, so a single success
+ * is not a recovery.
+ */
+export const SYNC_RECOVERY_CONFIRM_MS = 10 * 60 * 1000;
+
 export interface SyncHealth {
   recordFailure: (error: unknown) => Promise<void>;
   recordSuccess: () => Promise<void>;
@@ -40,7 +47,8 @@ const formatOutage = (ms: number): string => {
  * The SDK retries a failed sync forever and only writes to its own logger, so
  * a homeserver outage or a rejected token is otherwise invisible: no alert, no
  * umami event, while the app keeps reporting a successful start. This turns a
- * failing streak into a single alert, and reports the recovery.
+ * failing streak into a single alert, and reports the recovery once syncs have
+ * held for {@link SYNC_RECOVERY_CONFIRM_MS}.
  */
 export const createSyncHealth = (
   messageApp: MessageApp,
@@ -50,11 +58,13 @@ export const createSyncHealth = (
   let failureCount = 0;
   let firstFailureAt: number | null = null;
   let lastAlertAt: number | null = null;
+  let recoveringSince: number | null = null;
 
   const reset = () => {
     failureCount = 0;
     firstFailureAt = null;
     lastAlertAt = null;
+    recoveringSince = null;
   };
 
   return {
@@ -62,6 +72,7 @@ export const createSyncHealth = (
       const at = now();
       failureCount += 1;
       firstFailureAt ??= at;
+      recoveringSince = null;
 
       const worthReporting =
         failureCount >= SYNC_ALERT_AFTER_FAILURES ||
@@ -82,7 +93,13 @@ export const createSyncHealth = (
         reset();
         return;
       }
-      const outage = now() - (firstFailureAt ?? now());
+
+      const at = now();
+      recoveringSince ??= at;
+      if (at - recoveringSince < SYNC_RECOVERY_CONFIRM_MS) return;
+
+      // Syncs stopped failing at the first success, not at this confirmation.
+      const outage = recoveringSince - (firstFailureAt ?? recoveringSince);
       reset();
       await logWarning(
         messageApp,


### PR DESCRIPTION
## Problem

One flaky-network episode on the Tchap instance (night of 2026-08-20/21) produced ten debug notifications in ~70 minutes:

```
00:38:34 Matrix sync failing for 2m27s (4 attempts)
00:45:46 Matrix sync recovered after 9m40s
00:48:53 Matrix sync failing for 2m26s (4 attempts)
01:02:27 Matrix sync recovered after 16m0s
01:06:11 Matrix sync failing for 3m26s (4 attempts)
01:12:52 Matrix sync recovered after 10m7s
01:24:19 Matrix sync failing for 2m21s (3 attempts)
01:32:26 Matrix sync recovered after 10m27s
01:36:16 Matrix sync failing for 2m36s (4 attempts)
01:44:16 Matrix sync recovered after 10m36s
```

The homeserver was returning ETIMEDOUT/ESOCKETTIMEDOUT on and off across the whole window: one degraded period, not five.

`recordSuccess` called `reset()`, which cleared `lastAlertAt`. Two consequences: a recovery was announced on the first successful sync even when failures resumed seconds later, and `SYNC_REALERT_COOLDOWN_MS` never survived that single success, so the next streak alerted immediately.

## Change

The first success after an alert now starts a pending recovery instead of ending the outage. A failure during that window cancels it and keeps the outage (and its cooldown) alive. Only a success arriving at least `SYNC_RECOVERY_CONFIRM_MS` (10 min) after the pending recovery started reports "recovered" and resets the state. The reported duration still measures up to the first success, not to the confirmation.

No timers involved: the sync loop long-polls, so a healthy client reports a success at least every 30s.

On the logged episode this yields one alert, one 30-minute re-alert while sync was still flapping, and one recovery, instead of five of each.

## Tests

`tests/54.matrixSyncHealth.test.ts`: flapping stays a single incident, the re-alert cooldown survives a brief success, the outage duration is measured to the first success, and a confirmed recovery starts a fresh streak. Existing recovery tests updated for the confirmation window.