### PR TITLE
feat(health): add a Coolify-compatible healthcheck to every bot

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -25,6 +25,8 @@ LEGIFRANCE_API_URL="https://api.piste.gouv.fr/dila/legifrance/lf-engine-app"
 TEXT_SEARCH_YEARS_BACK=2
 
 TELEGRAM_BOT_TOKEN=""
+# Loopback port serving GET /health for the container healthcheck.
+TELEGRAM_HEALTH_PORT="3001"
 
 WHATSAPP_APP_SECRET=""
 WHATSAPP_USER_TOKEN=""
@@ -41,8 +43,10 @@ MATRIX_BOT_TOKEN=""
 MATRIX_BOT_TYPE="Matrix"
 
 MATRIX_ENCRYPTION_ENABLED=TRUE
+MATRIX_HEALTH_PORT="3002"
 
 SIGNAL_PHONE_NUMBER=""
+SIGNAL_HEALTH_PORT="3003"
 SIGNAL_DEVICE_NAME=""
 # URL of the signal-cli-rest-api service (docker-compose: http://signal-api:8080)
 SIGNAL_API_URL="http://localhost:8080"

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,9 @@ ENV NODE_ENV=production
 
 EXPOSE 3000
 
+# Each bot runs as its own process under concurrently, so the probe checks one
+# port per bot and skips the ones whose environment leaves them switched off.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD ["node", "dist/scripts/healthcheck.js", "telegram", "whatsapp", "matrix"]
+
 CMD ["npm", "run", "start:prod"]

--- a/Dockerfile.signal
+++ b/Dockerfile.signal
@@ -42,4 +42,7 @@ ENV NODE_ENV=production
 # companion signal-cli-rest-api service (see docker-compose.signal.yml), not
 # here. This image is just the Node bot.
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD ["node", "dist/scripts/healthcheck.js", "signal"]
+
 CMD ["npm", "run", "start-si:prod"]

--- a/apps/matrixApp.ts
+++ b/apps/matrixApp.ts
@@ -30,6 +30,8 @@ import {
   SyncingClient
 } from "../utils/matrixSyncHealth.ts";
 import { handleIncomingMessage } from "../utils/messageWorkflow.ts";
+import { mongoProbe, startHealthServer } from "../utils/healthServer.ts";
+import { healthPort } from "../utils/healthProbe.ts";
 // Persist sync token + crypto state
 import fs from "node:fs";
 import { StoreType } from "@matrix-org/matrix-sdk-crypto-nodejs";
@@ -104,10 +106,8 @@ const client = MATRIX_ENCRYPTION_ENABLED
 
 // The sync loop retries forever and only writes to the SDK logger, so without
 // this an outage is invisible outside stdout.
-attachSyncHealth(
-  client as unknown as SyncingClient,
-  createSyncHealth(matrixApp)
-);
+const syncHealth = createSyncHealth(matrixApp);
+attachSyncHealth(client as unknown as SyncingClient, syncHealth);
 
 AutojoinRoomsMixin.setupOnClient(client);
 AutojoinUpgradedRoomsMixin.setupOnClient(client); // optional but nice to have
@@ -300,6 +300,7 @@ const recentlyJoinedRooms = new Set<string>();
 await (async function () {
   // Register stopper
   let shuttingDown = false;
+  let healthServer: ReturnType<typeof startHealthServer> | undefined;
   try {
     const shutdown = async (signal: string) => {
       if (shuttingDown) return;
@@ -310,6 +311,7 @@ await (async function () {
       try {
         // Stop starting new work
         client.stop(); // sets stopSyncing=true (not async)
+        healthServer?.close();
 
         // Close DB cleanly
         await mongodbDisconnect();
@@ -348,6 +350,19 @@ await (async function () {
         : { tchapClient: client };
 
     startDailyNotificationJobs([matrixApp], messageOptions);
+
+    healthServer = startHealthServer(
+      matrixApp,
+      healthPort("matrix", process.env),
+      {
+        mongo: mongoProbe,
+        sync: () =>
+          syncHealth.isHealthy()
+            ? { ok: true }
+            : { ok: false, detail: "matrix sync outage" }
+      }
+    );
+
     console.log(`${matrixApp}: JOEL started successfully \u{2705}`);
   } catch (error) {
     await logError(matrixApp, "Failed to start app", error);

--- a/apps/signalApp.ts
+++ b/apps/signalApp.ts
@@ -6,10 +6,13 @@ import { SignalSession } from "../entities/SignalSession.ts";
 import { startDailyNotificationJobs } from "../notifications/notificationScheduler.ts";
 import { logError } from "../utils/debugLogger.ts";
 import { handleIncomingMessage } from "../utils/messageWorkflow.ts";
+import { mongoProbe, startHealthServer } from "../utils/healthServer.ts";
+import { healthPort } from "../utils/healthProbe.ts";
+import { isBlankEnv } from "../utils/env.utils.ts";
 
 const { SIGNAL_PHONE_NUMBER, SIGNAL_API_URL } = process.env;
 
-if (SIGNAL_PHONE_NUMBER === undefined || SIGNAL_API_URL === undefined) {
+if (isBlankEnv(SIGNAL_PHONE_NUMBER) || isBlankEnv(SIGNAL_API_URL)) {
   console.log("Signal: env is not set, bot did not start \u{1F6A9}");
   process.exit(0);
 }
@@ -24,6 +27,7 @@ interface ISignalMessage {
   };
 }
 await (async () => {
+  let healthServer: ReturnType<typeof startHealthServer> | undefined;
   try {
     // Talks to the signal-cli-rest-api service over HTTP (send) + WebSocket
     // (receive). No local signal-cli process.
@@ -40,6 +44,7 @@ await (async () => {
 
       try {
         signalCli.disconnect();
+        healthServer?.close();
 
         // Close DB cleanly
         await mongodbDisconnect();
@@ -96,6 +101,19 @@ await (async () => {
     });
 
     startDailyNotificationJobs(["Signal"], { signalCli: signalCli });
+
+    healthServer = startHealthServer(
+      "Signal",
+      healthPort("signal", process.env),
+      {
+        mongo: mongoProbe,
+        signalSocket: () =>
+          signalCli.isConnected
+            ? { ok: true }
+            : { ok: false, detail: "signal-cli WebSocket disconnected" }
+      }
+    );
+
     console.log(`Signal: JOEL started successfully \u{2705}`);
   } catch (error) {
     await logError("Signal", "Failed to start Signal app", error);

--- a/apps/telegramApp.ts
+++ b/apps/telegramApp.ts
@@ -6,9 +6,12 @@ import { TelegramSession } from "../entities/TelegramSession.ts";
 import { startDailyNotificationJobs } from "../notifications/notificationScheduler.ts";
 import { handleIncomingMessage } from "../utils/messageWorkflow.ts";
 import { logError, logTelegramDebugStatus } from "../utils/debugLogger.ts";
+import { mongoProbe, startHealthServer } from "../utils/healthServer.ts";
+import { healthPort } from "../utils/healthProbe.ts";
+import { isBlankEnv } from "../utils/env.utils.ts";
 
 const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
-if (TELEGRAM_BOT_TOKEN === undefined) {
+if (isBlankEnv(TELEGRAM_BOT_TOKEN)) {
   console.log("Telegram: env is not set, bot did not start \u{1F6A9}");
   process.exit(0);
 }
@@ -17,10 +20,21 @@ if (TELEGRAM_BOT_TOKEN === undefined) {
 // unresolved Coolify "{{...}}" placeholder) before the bot starts.
 logTelegramDebugStatus();
 
+/**
+ * How long a getMe result stands in for the polling connection.
+ *
+ * Telegraf exposes no "last update received" signal, so reaching the Bot API
+ * is the available proof that the token still works and Telegram is
+ * answering. Memoizing keeps a 30s container probe to one API call.
+ */
+const TELEGRAM_API_TTL_MS = 20_000;
+const TELEGRAM_API_TIMEOUT_MS = 5000;
+
 await (async () => {
   const bot = new Telegraf(TELEGRAM_BOT_TOKEN);
   // Register stopper
   let shuttingDown = false;
+  let healthServer: ReturnType<typeof startHealthServer> | undefined;
   try {
     const shutdown = async (signal: string) => {
       if (shuttingDown) return;
@@ -31,6 +45,7 @@ await (async () => {
       try {
         // Stop starting new work
         bot.stop(); // sets stopSyncing=true (not async)
+        healthServer?.close();
 
         // Close DB cleanly
         await mongodbDisconnect();
@@ -83,6 +98,44 @@ await (async () => {
     startDailyNotificationJobs(["Telegram"], {
       telegramBotToken: TELEGRAM_BOT_TOKEN
     });
+
+    let apiCheckedAt = 0;
+    let apiReachable = true;
+    healthServer = startHealthServer(
+      "Telegram",
+      healthPort("telegram", process.env),
+      {
+        mongo: mongoProbe,
+        telegramApi: async () => {
+          if (Date.now() - apiCheckedAt < TELEGRAM_API_TTL_MS)
+            return apiReachable
+              ? { ok: true }
+              : { ok: false, detail: "Telegram API unreachable" };
+
+          try {
+            await Promise.race([
+              bot.telegram.getMe(),
+              new Promise((_, reject) => {
+                setTimeout(() => {
+                  reject(new Error("Telegram getMe timed out"));
+                }, TELEGRAM_API_TIMEOUT_MS).unref();
+              })
+            ]);
+            apiReachable = true;
+            return { ok: true };
+          } catch (error) {
+            apiReachable = false;
+            return {
+              ok: false,
+              detail: error instanceof Error ? error.message : String(error)
+            };
+          } finally {
+            apiCheckedAt = Date.now();
+          }
+        }
+      }
+    );
+
     console.log(`Telegram: JOEL started successfully \u{2705}`);
     await bot.launch();
   } catch (error) {

--- a/apps/whatsAppApp.ts
+++ b/apps/whatsAppApp.ts
@@ -24,6 +24,12 @@ import { handleIncomingMessage } from "../utils/messageWorkflow.ts";
 import { getCachedStats } from "../commands/stats.ts";
 import { createTtlDedup } from "../utils/webhookDedup.ts";
 import { textFromMessage } from "../utils/whatsAppMessageText.ts";
+import {
+  buildHealthReport,
+  HEALTH_PATH,
+  mongoProbe
+} from "../utils/healthServer.ts";
+import { isBlankEnv } from "../utils/env.utils.ts";
 
 const MAX_AGE_SEC = 5 * 60;
 const DUPLICATE_MESSAGE_TTL_MS = MAX_AGE_SEC * 1000;
@@ -44,9 +50,9 @@ const {
 
 export function getWhatsAppAPI(): WhatsAppAPI {
   if (
-    WHATSAPP_USER_TOKEN === undefined ||
-    WHATSAPP_APP_SECRET === undefined ||
-    WHATSAPP_PHONE_NUMBER === undefined
+    isBlankEnv(WHATSAPP_USER_TOKEN) ||
+    isBlankEnv(WHATSAPP_APP_SECRET) ||
+    isBlankEnv(WHATSAPP_PHONE_NUMBER)
   ) {
     console.log("WhatsApp: env is not set, bot did not start \u{1F6A9}");
     process.exit(0);
@@ -145,6 +151,20 @@ await (async function () {
         }
       })
     );
+
+    // The bot is webhook-driven, so serving this port is itself the proof that
+    // it can still receive: the only dependency left to assert is the database.
+    const startedAt = Date.now();
+    app.get(HEALTH_PATH, (_req, res) => {
+      void (async () => {
+        const report = await buildHealthReport(
+          "WhatsApp",
+          { mongo: mongoProbe },
+          (Date.now() - startedAt) / 1000
+        );
+        res.status(report.statusCode).json(report.body);
+      })();
+    });
 
     const incomingMessageTargets = new Set<string>();
 

--- a/docker-compose.signal.yml
+++ b/docker-compose.signal.yml
@@ -33,6 +33,12 @@ services:
       - SIGNAL_API_URL=http://signalapi:8080
     env_file:
       - .env
+    healthcheck:
+      test: ["CMD", "node", "dist/scripts/healthcheck.js", "signal"]
+      interval: 30s
+      timeout: 5s
+      start_period: 60s
+      retries: 3
     depends_on:
       # wait until signal-cli-rest-api is healthy so the bot's first WebSocket
       # connect doesn't race the daemon's startup.

--- a/scripts/healthcheck.ts
+++ b/scripts/healthcheck.ts
@@ -1,0 +1,10 @@
+import "dotenv/config";
+import { runHealthcheck } from "../utils/healthProbe.ts";
+
+const { exitCode, lines } = await runHealthcheck(
+  process.argv.slice(2),
+  process.env
+);
+
+for (const line of lines) console.log(`Healthcheck: ${line}`);
+process.exit(exitCode);

--- a/tests/46.signalRestClient.test.ts
+++ b/tests/46.signalRestClient.test.ts
@@ -308,3 +308,40 @@ describe("SignalRestClient polls", () => {
     client.disconnect();
   });
 });
+
+describe("SignalRestClient.isConnected", () => {
+  it("tracks the receive socket from connect to disconnect", async () => {
+    const client = new SignalRestClient(
+      "http://signal-api:8080",
+      "+33111111111",
+      (url) => new FakeWS(url)
+    );
+
+    expect(client.isConnected).toBe(false);
+
+    const connected = client.connect();
+    FakeWS.last.emit("open");
+    await connected;
+    expect(client.isConnected).toBe(true);
+
+    client.disconnect();
+    expect(client.isConnected).toBe(false);
+  });
+
+  it("reports a dropped socket before the reconnect lands", () => {
+    const client = new SignalRestClient(
+      "http://signal-api:8080",
+      "+33111111111",
+      (url) => new FakeWS(url)
+    );
+    vi.useFakeTimers();
+    void client.connect();
+    FakeWS.last.emit("open");
+    FakeWS.last.emit("close");
+
+    expect(client.isConnected).toBe(false);
+
+    client.disconnect();
+    vi.useRealTimers();
+  });
+});

--- a/tests/54.matrixSyncHealth.test.ts
+++ b/tests/54.matrixSyncHealth.test.ts
@@ -262,3 +262,46 @@ describe("attachSyncHealth", () => {
     expect(logWarningSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("sync health readiness", () => {
+  it("is healthy before any failure", () => {
+    expect(healthWithClock().isHealthy()).toBe(true);
+  });
+
+  it("stays healthy while failures are below the alert threshold", async () => {
+    const health = healthWithClock();
+
+    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES - 1; i++) {
+      clock += 1000;
+      await health.recordFailure(tokenError());
+    }
+
+    expect(health.isHealthy()).toBe(true);
+  });
+
+  it("turns unhealthy once the outage is reported", async () => {
+    const health = healthWithClock();
+
+    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
+      clock += 1000;
+      await health.recordFailure(tokenError());
+    }
+
+    expect(health.isHealthy()).toBe(false);
+  });
+
+  it("stays unhealthy until the recovery is confirmed", async () => {
+    const health = healthWithClock();
+
+    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
+      clock += 1000;
+      await health.recordFailure(tokenError());
+    }
+    await health.recordSuccess();
+    expect(health.isHealthy()).toBe(false);
+
+    clock += SYNC_RECOVERY_CONFIRM_MS;
+    await health.recordSuccess();
+    expect(health.isHealthy()).toBe(true);
+  });
+});

--- a/tests/56.healthServer.test.ts
+++ b/tests/56.healthServer.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { AddressInfo } from "node:net";
+
+const { logErrorSpy } = vi.hoisted(() => ({
+  logErrorSpy: vi.fn(() => Promise.resolve())
+}));
+
+vi.mock("../utils/debugLogger.ts", () => ({
+  logError: logErrorSpy
+}));
+
+const { buildHealthReport, HEALTH_PATH, startHealthServer } =
+  await import("../utils/healthServer.ts");
+
+const servers: ReturnType<typeof startHealthServer>[] = [];
+
+const listenOnFreePort = async (
+  probes: Parameters<typeof startHealthServer>[2]
+): Promise<string> => {
+  const server = startHealthServer("Telegram", 0, probes);
+  servers.push(server);
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  const { port } = server.address() as AddressInfo;
+  return `http://127.0.0.1:${String(port)}`;
+};
+
+afterEach(() => {
+  for (const server of servers.splice(0)) server.close();
+});
+
+describe("buildHealthReport", () => {
+  it("reports 200 when every probe passes", async () => {
+    const report = await buildHealthReport(
+      "Matrix",
+      { mongo: () => ({ ok: true }), sync: () => ({ ok: true }) },
+      12.4
+    );
+
+    expect(report.statusCode).toBe(200);
+    expect(report.body).toEqual({
+      status: "ok",
+      app: "Matrix",
+      uptimeSeconds: 12,
+      checks: { mongo: { ok: true }, sync: { ok: true } }
+    });
+  });
+
+  it("reports 503 and keeps the detail when one probe fails", async () => {
+    const report = await buildHealthReport(
+      "Signal",
+      {
+        mongo: () => ({ ok: true }),
+        signalSocket: () => ({ ok: false, detail: "disconnected" })
+      },
+      1
+    );
+
+    expect(report.statusCode).toBe(503);
+    expect(report.body.status).toBe("unhealthy");
+    expect(report.body.checks.signalSocket).toEqual({
+      ok: false,
+      detail: "disconnected"
+    });
+  });
+
+  it("treats a throwing probe as a failure carrying its message", async () => {
+    const report = await buildHealthReport(
+      "Telegram",
+      {
+        telegramApi: () => {
+          throw new Error("getMe timed out");
+        }
+      },
+      0
+    );
+
+    expect(report.statusCode).toBe(503);
+    expect(report.body.checks.telegramApi).toEqual({
+      ok: false,
+      detail: "getMe timed out"
+    });
+  });
+
+  it("awaits asynchronous probes", async () => {
+    const report = await buildHealthReport(
+      "Telegram",
+      { slow: () => Promise.resolve({ ok: false, detail: "late" }) },
+      0
+    );
+
+    expect(report.statusCode).toBe(503);
+    expect(report.body.checks.slow).toEqual({ ok: false, detail: "late" });
+  });
+});
+
+describe("startHealthServer", () => {
+  it("serves 200 on the health path while probes pass", async () => {
+    const base = await listenOnFreePort({ mongo: () => ({ ok: true }) });
+
+    const response = await fetch(`${base}${HEALTH_PATH}`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      status: "ok",
+      app: "Telegram"
+    });
+  });
+
+  it("serves 503 once a probe fails", async () => {
+    let healthy = true;
+    const base = await listenOnFreePort({ link: () => ({ ok: healthy }) });
+
+    expect((await fetch(`${base}${HEALTH_PATH}`)).status).toBe(200);
+    healthy = false;
+    expect((await fetch(`${base}${HEALTH_PATH}`)).status).toBe(503);
+  });
+
+  it("ignores the query string on the health path", async () => {
+    const base = await listenOnFreePort({ mongo: () => ({ ok: true }) });
+
+    expect((await fetch(`${base}${HEALTH_PATH}?full=1`)).status).toBe(200);
+  });
+
+  it("answers 404 on any other path", async () => {
+    const base = await listenOnFreePort({ mongo: () => ({ ok: true }) });
+
+    expect((await fetch(`${base}/`)).status).toBe(404);
+    expect((await fetch(`${base}/metrics`)).status).toBe(404);
+  });
+
+  it("answers 404 on a non-GET request to the health path", async () => {
+    const base = await listenOnFreePort({ mongo: () => ({ ok: true }) });
+
+    expect(
+      (await fetch(`${base}${HEALTH_PATH}`, { method: "POST" })).status
+    ).toBe(404);
+  });
+});
+
+describe("mongoProbe", () => {
+  it("passes while mongoose holds a connection", async () => {
+    const { mongoProbe } = await import("../utils/healthServer.ts");
+
+    expect(mongoProbe()).toEqual({ ok: true });
+  });
+});

--- a/tests/57.healthProbe.test.ts
+++ b/tests/57.healthProbe.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  DEFAULT_HEALTH_PORTS,
+  healthPort,
+  isAppEnabled,
+  resolveTargets,
+  runHealthcheck
+} from "../utils/healthProbe.ts";
+
+const telegramEnv = { TELEGRAM_BOT_TOKEN: "token" };
+const signalEnv = {
+  SIGNAL_PHONE_NUMBER: "+33600000000",
+  SIGNAL_API_URL: "http://signalapi:8080"
+};
+const whatsAppEnv = {
+  WHATSAPP_USER_TOKEN: "t",
+  WHATSAPP_APP_SECRET: "s",
+  WHATSAPP_PHONE_NUMBER: "p"
+};
+
+const okResponse = () => new Response("{}", { status: 200 });
+const failResponse = () => new Response("{}", { status: 503 });
+
+describe("isAppEnabled", () => {
+  it("requires every variable the bot needs to start", () => {
+    expect(isAppEnabled("signal", signalEnv)).toBe(true);
+    expect(
+      isAppEnabled("signal", { SIGNAL_PHONE_NUMBER: "+33600000000" })
+    ).toBe(false);
+  });
+
+  it("treats a blank value as unset, like the bots do", () => {
+    expect(isAppEnabled("telegram", { TELEGRAM_BOT_TOKEN: "  " })).toBe(false);
+  });
+});
+
+describe("healthPort", () => {
+  it("defaults when the variable is unset or unusable", () => {
+    expect(healthPort("matrix", {})).toBe(DEFAULT_HEALTH_PORTS.matrix);
+    expect(healthPort("matrix", { MATRIX_HEALTH_PORT: "nope" })).toBe(
+      DEFAULT_HEALTH_PORTS.matrix
+    );
+  });
+
+  it("reads the configured port", () => {
+    expect(healthPort("matrix", { MATRIX_HEALTH_PORT: "9002" })).toBe(9002);
+    expect(healthPort("whatsapp", { WHATSAPP_APP_PORT: "8080" })).toBe(8080);
+  });
+});
+
+describe("resolveTargets", () => {
+  it("keeps only the apps the environment enables", () => {
+    const { targets } = resolveTargets(
+      ["telegram", "whatsapp", "matrix"],
+      telegramEnv
+    );
+
+    expect(targets.map((target) => target.name)).toEqual(["telegram"]);
+    expect(targets[0].url).toBe(
+      `http://127.0.0.1:${String(DEFAULT_HEALTH_PORTS.telegram)}/health`
+    );
+  });
+
+  it("names arguments that match no app", () => {
+    const { unknown } = resolveTargets(["telegram", "carrier-pigeon"], {});
+
+    expect(unknown).toEqual(["carrier-pigeon"]);
+  });
+});
+
+describe("runHealthcheck", () => {
+  it("succeeds when every enabled app answers 200", async () => {
+    const fetchImpl = vi.fn(() => Promise.resolve(okResponse()));
+
+    const result = await runHealthcheck(
+      ["telegram", "whatsapp", "matrix"],
+      { ...telegramEnv, ...whatsAppEnv },
+      { fetchImpl: fetchImpl as unknown as typeof fetch }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails when one enabled app is unhealthy", async () => {
+    const fetchImpl = vi.fn((url: string) =>
+      Promise.resolve(
+        url.includes(String(DEFAULT_HEALTH_PORTS.telegram))
+          ? failResponse()
+          : okResponse()
+      )
+    );
+
+    const result = await runHealthcheck(
+      ["telegram", "whatsapp"],
+      { ...telegramEnv, ...whatsAppEnv },
+      { fetchImpl: fetchImpl as unknown as typeof fetch }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.lines).toEqual(["telegram: HTTP 503"]);
+  });
+
+  it("fails when an app refuses the connection", async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.reject(new Error("ECONNREFUSED 127.0.0.1:3003"))
+    );
+
+    const result = await runHealthcheck(["signal"], signalEnv, {
+      fetchImpl: fetchImpl as unknown as typeof fetch
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.lines).toEqual(["signal: ECONNREFUSED 127.0.0.1:3003"]);
+  });
+
+  it("skips an app the environment leaves switched off", async () => {
+    const fetchImpl = vi.fn(() => Promise.resolve(okResponse()));
+
+    const result = await runHealthcheck(
+      ["telegram", "whatsapp", "matrix"],
+      telegramEnv,
+      { fetchImpl: fetchImpl as unknown as typeof fetch }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails when no named app is configured", async () => {
+    const fetchImpl = vi.fn(() => Promise.resolve(okResponse()));
+
+    const result = await runHealthcheck(
+      ["telegram", "matrix"],
+      {},
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch
+      }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.lines[0]).toContain("no configured app");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("fails on an unknown app name rather than probing nothing", async () => {
+    const result = await runHealthcheck(
+      ["signal", "smoke-signals"],
+      signalEnv,
+      {
+        fetchImpl: vi.fn(() =>
+          Promise.resolve(okResponse())
+        ) as unknown as typeof fetch
+      }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.lines[0]).toContain("smoke-signals");
+  });
+
+  it("times out a probe that never answers", async () => {
+    const fetchImpl = vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new Error("aborted"));
+          });
+        })
+    );
+
+    const result = await runHealthcheck(["signal"], signalEnv, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      timeoutMs: 10
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.lines[0]).toContain("signal:");
+  });
+});

--- a/utils/env.utils.ts
+++ b/utils/env.utils.ts
@@ -34,3 +34,17 @@ export const missingEnvVars = (
   Object.entries(vars)
     .filter(([, value]) => isBlankEnv(value))
     .map(([name]) => name);
+
+/**
+ * Reads a TCP port from the environment, falling back when the value is
+ * absent, blank or not a port number.
+ */
+export const parsePortEnv = (
+  value: string | undefined,
+  fallback: number
+): number => {
+  if (isBlankEnv(value)) return fallback;
+  const port = Number(value.trim());
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return fallback;
+  return port;
+};

--- a/utils/healthProbe.ts
+++ b/utils/healthProbe.ts
@@ -1,0 +1,160 @@
+import { HEALTH_PATH } from "./healthServer.ts";
+import { isBlankEnv, parsePortEnv } from "./env.utils.ts";
+
+export type HealthAppName = "telegram" | "whatsapp" | "matrix" | "signal";
+
+export const HEALTH_APP_NAMES: HealthAppName[] = [
+  "telegram",
+  "whatsapp",
+  "matrix",
+  "signal"
+];
+
+/** Default health ports. WhatsApp answers on the port it already serves on. */
+export const DEFAULT_HEALTH_PORTS: Record<HealthAppName, number> = {
+  whatsapp: 3000,
+  telegram: 3001,
+  matrix: 3002,
+  signal: 3003
+};
+
+export interface HealthTarget {
+  name: HealthAppName;
+  port: number;
+  url: string;
+}
+
+type Env = Record<string, string | undefined>;
+
+/**
+ * Variables each bot requires to start. A bot whose variables are unset exits
+ * with status 0 on purpose, so its port stays closed and probing it would fail
+ * a container that is running exactly the subset it was configured for.
+ */
+const REQUIRED_ENV: Record<HealthAppName, string[]> = {
+  telegram: ["TELEGRAM_BOT_TOKEN"],
+  whatsapp: [
+    "WHATSAPP_USER_TOKEN",
+    "WHATSAPP_APP_SECRET",
+    "WHATSAPP_PHONE_NUMBER"
+  ],
+  matrix: ["MATRIX_HOME_URL", "MATRIX_BOT_TOKEN", "MATRIX_BOT_TYPE"],
+  signal: ["SIGNAL_PHONE_NUMBER", "SIGNAL_API_URL"]
+};
+
+const PORT_ENV: Record<HealthAppName, string> = {
+  telegram: "TELEGRAM_HEALTH_PORT",
+  whatsapp: "WHATSAPP_APP_PORT",
+  matrix: "MATRIX_HEALTH_PORT",
+  signal: "SIGNAL_HEALTH_PORT"
+};
+
+export const isHealthAppName = (value: string): value is HealthAppName =>
+  (HEALTH_APP_NAMES as string[]).includes(value);
+
+export const healthPort = (name: HealthAppName, env: Env): number =>
+  parsePortEnv(env[PORT_ENV[name]], DEFAULT_HEALTH_PORTS[name]);
+
+export const isAppEnabled = (name: HealthAppName, env: Env): boolean =>
+  REQUIRED_ENV[name].every((variable) => !isBlankEnv(env[variable]));
+
+/**
+ * Turns the app names a container runs into the endpoints worth probing.
+ *
+ * The names come from the image's HEALTHCHECK arguments rather than from the
+ * environment: both images are fed the same .env file, so only the command
+ * line distinguishes the multi-bot image from the Signal-only one.
+ */
+export const resolveTargets = (
+  names: string[],
+  env: Env
+): { targets: HealthTarget[]; unknown: string[] } => {
+  const unknown = names.filter((name) => !isHealthAppName(name));
+  const targets = names
+    .filter(isHealthAppName)
+    .filter((name) => isAppEnabled(name, env))
+    .map((name) => {
+      const port = healthPort(name, env);
+      return {
+        name,
+        port,
+        url: `http://127.0.0.1:${String(port)}${HEALTH_PATH}`
+      };
+    });
+  return { targets, unknown };
+};
+
+export interface ProbeResult {
+  exitCode: 0 | 1;
+  lines: string[];
+}
+
+export interface ProbeOptions {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 4000;
+
+const probeOne = async (
+  target: HealthTarget,
+  fetchImpl: typeof fetch,
+  timeoutMs: number
+): Promise<string | null> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+  try {
+    const response = await fetchImpl(target.url, { signal: controller.signal });
+    if (response.status === 200) return null;
+    return `${target.name}: HTTP ${String(response.status)}`;
+  } catch (error) {
+    return `${target.name}: ${error instanceof Error ? error.message : String(error)}`;
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/**
+ * Probes every enabled app named on the command line.
+ *
+ * A container with no enabled app is reported unhealthy: it runs no bot, so
+ * "nothing to check" is a misconfigured deployment, not a passing one.
+ */
+export const runHealthcheck = async (
+  names: string[],
+  env: Env,
+  options: ProbeOptions = {}
+): Promise<ProbeResult> => {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const { targets, unknown } = resolveTargets(names, env);
+
+  if (unknown.length > 0) {
+    return {
+      exitCode: 1,
+      lines: [`unknown app name(s): ${unknown.join(", ")}`]
+    };
+  }
+
+  if (targets.length === 0) {
+    return {
+      exitCode: 1,
+      lines: [`no configured app among: ${names.join(", ")}`]
+    };
+  }
+
+  const failures = (
+    await Promise.all(
+      targets.map((target) => probeOne(target, fetchImpl, timeoutMs))
+    )
+  ).filter((failure): failure is string => failure !== null);
+
+  return failures.length === 0
+    ? {
+        exitCode: 0,
+        lines: [`healthy: ${targets.map((t) => t.name).join(", ")}`]
+      }
+    : { exitCode: 1, lines: failures };
+};

--- a/utils/healthServer.ts
+++ b/utils/healthServer.ts
@@ -1,0 +1,119 @@
+import http from "node:http";
+import mongoose from "mongoose";
+import { MessageApp } from "../types.ts";
+import { logError } from "./debugLogger.ts";
+
+/** Path the container HEALTHCHECK probes on every app. */
+export const HEALTH_PATH = "/health";
+
+/** Loopback only: the container's own probe is the sole caller. */
+const HEALTH_HOST = "127.0.0.1";
+
+export interface HealthCheck {
+  ok: boolean;
+  detail?: string;
+}
+
+export type HealthProbe = () => HealthCheck | Promise<HealthCheck>;
+
+export interface HealthReport {
+  statusCode: 200 | 503;
+  body: {
+    status: "ok" | "unhealthy";
+    app: MessageApp;
+    uptimeSeconds: number;
+    checks: Record<string, HealthCheck>;
+  };
+}
+
+/** True while mongoose holds an open connection. */
+export const mongoProbe: HealthProbe = () => {
+  const ready =
+    mongoose.connection.readyState === mongoose.ConnectionStates.connected;
+  return ready
+    ? { ok: true }
+    : {
+        ok: false,
+        detail: `mongoose readyState ${String(mongoose.connection.readyState)}`
+      };
+};
+
+/**
+ * Runs every probe and folds the results into one report. A probe that throws
+ * counts as a failure carrying its message, so a broken probe can never make
+ * an unhealthy app look healthy.
+ */
+export const buildHealthReport = async (
+  app: MessageApp,
+  probes: Record<string, HealthProbe>,
+  uptimeSeconds: number
+): Promise<HealthReport> => {
+  const checks: Record<string, HealthCheck> = {};
+
+  for (const [name, probe] of Object.entries(probes)) {
+    try {
+      checks[name] = await probe();
+    } catch (error) {
+      checks[name] = {
+        ok: false,
+        detail: error instanceof Error ? error.message : String(error)
+      };
+    }
+  }
+
+  const ok = Object.values(checks).every((check) => check.ok);
+  return {
+    statusCode: ok ? 200 : 503,
+    body: {
+      status: ok ? "ok" : "unhealthy",
+      app,
+      uptimeSeconds: Math.round(uptimeSeconds),
+      checks
+    }
+  };
+};
+
+/**
+ * Serves GET /health for one bot process.
+ *
+ * The Telegram, Matrix and Signal bots hold no HTTP server of their own, and
+ * the three of them share a container, so each needs its own port for the
+ * image's HEALTHCHECK to tell a live bot from a dead one. WhatsApp instead
+ * mounts {@link buildHealthReport} on the express app it already listens with.
+ *
+ * The returned server is unref'd: a stalled probe connection must not keep the
+ * process alive once the bot has shut down.
+ */
+export const startHealthServer = (
+  app: MessageApp,
+  port: number,
+  probes: Record<string, HealthProbe>
+): http.Server => {
+  const startedAt = Date.now();
+
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      if (req.method !== "GET" || req.url?.split("?")[0] !== HEALTH_PATH) {
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "not found" }));
+        return;
+      }
+
+      const report = await buildHealthReport(
+        app,
+        probes,
+        (Date.now() - startedAt) / 1000
+      );
+      res.writeHead(report.statusCode, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(report.body));
+    })();
+  });
+
+  server.on("error", (error) => {
+    void logError(app, `Health server failed on port ${String(port)}`, error);
+  });
+
+  server.listen(port, HEALTH_HOST);
+  server.unref();
+  return server;
+};

--- a/utils/matrixSyncHealth.ts
+++ b/utils/matrixSyncHealth.ts
@@ -21,6 +21,8 @@ export const SYNC_RECOVERY_CONFIRM_MS = 10 * 60 * 1000;
 export interface SyncHealth {
   recordFailure: (error: unknown) => Promise<void>;
   recordSuccess: () => Promise<void>;
+  /** False while an outage has been reported and no recovery confirmed yet. */
+  isHealthy: () => boolean;
 }
 
 /** The one sync entry point of a matrix-bot-sdk client. */
@@ -68,6 +70,7 @@ export const createSyncHealth = (
   };
 
   return {
+    isHealthy: () => lastAlertAt == null,
     recordFailure: async (error: unknown) => {
       const at = now();
       failureCount += 1;

--- a/utils/signalRestClient.ts
+++ b/utils/signalRestClient.ts
@@ -108,6 +108,11 @@ export class SignalRestClient extends EventEmitter {
     this.wsUrl = `${wsBase}/v1/receive/${phoneNumber}`;
   }
 
+  /** True while the receive WebSocket is open. */
+  get isConnected(): boolean {
+    return this.ws !== null;
+  }
+
   connect(): Promise<void> {
     this.intentionalShutdown = false;
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## What

Every bot now serves `GET /health`, and both images declare a Docker `HEALTHCHECK` so Coolify can see a container as healthy or unhealthy without any UI configuration.

The endpoint returns 200 only when the process is up **and** its critical dependencies are usable, so a silently broken bot (dead Matrix sync, dropped Signal socket, lost Mongo connection) is restarted instead of looking fine forever.

## How

**Health endpoint** (`utils/healthServer.ts`): a small `node:http` server serving `GET /health`, bound to `127.0.0.1` since the container's own probe is the only caller. 200 when every probe passes, 503 otherwise, JSON body either way:

```json
{ "status": "ok", "app": "Matrix", "uptimeSeconds": 412,
  "checks": { "mongo": { "ok": true }, "sync": { "ok": true } } }
```

A probe that throws counts as a failure carrying its message, so a broken probe can never make an unhealthy app read as healthy. The server is `unref`'d and closed on shutdown.

**Probes per app:**

| App | Checks |
| --- | --- |
| Telegram | mongo + `getMe`, memoized 20s so a 30s container probe means one API call |
| Matrix / Tchap | mongo + the existing `createSyncHealth`, via a new `isHealthy()` (false exactly while an outage is reported and no recovery confirmed) |
| Signal | mongo + a new `SignalRestClient.isConnected` (receive WebSocket open) |
| WhatsApp | mongo, on the express app it already listens with. It is webhook-driven, so serving the port is itself the receive-side proof |

**Ports:** WhatsApp answers on `WHATSAPP_APP_PORT` (3000). New optional `TELEGRAM_HEALTH_PORT` (3001), `MATRIX_HEALTH_PORT` (3002), `SIGNAL_HEALTH_PORT` (3003), all with defaults, documented in `.env.template`.

**Probe** (`utils/healthProbe.ts` + `scripts/healthcheck.ts`): the main image runs three bots as separate processes under `concurrently`, so one port per bot is the only way to tell a live bot from a dead one. Candidate apps come from the `HEALTHCHECK` arguments, since both images are fed the same `.env` and only the command line distinguishes them:

```
Dockerfile        node dist/scripts/healthcheck.js telegram whatsapp matrix
Dockerfile.signal node dist/scripts/healthcheck.js signal
```

Enablement comes from the environment: a bot whose variables are unset exits 0 on purpose, so its port is skipped rather than failing the container. A container with no enabled app is reported unhealthy, since it runs no bot. Uses `fetch` with a 4s timeout, so nothing needs curl or wget in `node:24-slim`. `docker-compose.signal.yml` carries a matching explicit `healthcheck:` block next to the existing `service_healthy` dependency.

**Drive-by:** Telegram, WhatsApp and Signal now gate on `isBlankEnv` like Matrix already did, so an unresolved Coolify placeholder (an empty string) reads as unset in both the app and the probe rather than only in one of them.

## Testing

- `tests/56.healthServer.test.ts`: status codes, JSON shape, throwing and async probes, query strings, 404 on other paths and on non-GET.
- `tests/57.healthProbe.test.ts`: env gating, port resolution, unknown names, no-app-configured, non-200, connection refused, timeout.
- Added cases to the existing Matrix sync-health and Signal client suites for `isHealthy()` and `isConnected`.
- Full suite: 61 files, 881 tests passing. Lint and build clean.
- Smoke-tested the compiled `dist/scripts/healthcheck.js` against a live endpoint (exit 0) and against a closed port (exit 1).