### PR TITLE
fix(telegram): retry getUpdates conflicts and fail deaf launches

### DIFF
--- a/apps/telegramApp.ts
+++ b/apps/telegramApp.ts
@@ -5,9 +5,17 @@ import { mongodbConnect, mongodbDisconnect } from "../db.ts";
 import { TelegramSession } from "../entities/TelegramSession.ts";
 import { startDailyNotificationJobs } from "../notifications/notificationScheduler.ts";
 import { handleIncomingMessage } from "../utils/messageWorkflow.ts";
-import { logError, logTelegramDebugStatus } from "../utils/debugLogger.ts";
+import {
+  logError,
+  logTelegramDebugStatus,
+  logWarning
+} from "../utils/debugLogger.ts";
 import { mongoProbe, startHealthServer } from "../utils/healthServer.ts";
 import { healthPort } from "../utils/healthProbe.ts";
+import {
+  launchWithConflictRetry,
+  pollingProbe
+} from "../utils/telegramLaunch.ts";
 import { isBlankEnv } from "../utils/env.utils.ts";
 
 const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
@@ -34,6 +42,7 @@ await (async () => {
   const bot = new Telegraf(TELEGRAM_BOT_TOKEN);
   // Register stopper
   let shuttingDown = false;
+  let polling = false;
   let healthServer: ReturnType<typeof startHealthServer> | undefined;
   try {
     const shutdown = async (signal: string) => {
@@ -43,8 +52,9 @@ await (async () => {
       console.log(`Telegram: Received ${signal}, shutting down...`);
 
       try {
-        // Stop starting new work
-        bot.stop(); // sets stopSyncing=true (not async)
+        // Stop starting new work. Telegraf throws when asked to stop a bot
+        // that never reached its polling loop.
+        if (polling) bot.stop(); // sets stopSyncing=true (not async)
         healthServer?.close();
 
         // Close DB cleanly
@@ -106,6 +116,7 @@ await (async () => {
       healthPort("telegram", process.env),
       {
         mongo: mongoProbe,
+        polling: pollingProbe(() => polling),
         telegramApi: async () => {
           if (Date.now() - apiCheckedAt < TELEGRAM_API_TTL_MS)
             return apiReachable
@@ -137,8 +148,29 @@ await (async () => {
     );
 
     console.log(`Telegram: JOEL started successfully \u{2705}`);
-    await bot.launch();
+    await launchWithConflictRetry({
+      launch: async () => {
+        polling = true;
+        try {
+          await bot.launch();
+        } finally {
+          polling = false;
+        }
+      },
+      onConflict: (attempt, delayMs) => {
+        void logWarning(
+          "Telegram",
+          `Another instance is polling this bot token (attempt ${String(attempt)}); retrying in ${String(delayMs / 1000)}s`
+        );
+      }
+    });
   } catch (error) {
     await logError("Telegram", "Failed to start app", error);
+    // Exit non-zero so concurrently tears the container down and the restart
+    // policy recovers it, instead of lingering as a process that answers the
+    // Bot API while receiving no update.
+    healthServer?.close();
+    await mongodbDisconnect();
+    process.exit(1);
   }
 })();

--- a/tests/49.debugLogger.test.ts
+++ b/tests/49.debugLogger.test.ts
@@ -15,6 +15,7 @@ vi.mock("axios", () => ({
   isAxiosError: () => false
 }));
 vi.mock("../utils/umami.ts", () => ({ default: { log: umamiLogSpy } }));
+vi.mock("node:os", () => ({ default: { hostname: () => "c0ffee1nstance" } }));
 
 process.env.DEBUG_CHAT_ID = "debug-chat-id";
 process.env.TELEGRAM_DEBUG_BOT_TOKEN = "debug-bot-token";
@@ -37,6 +38,12 @@ describe("logError", () => {
 
     const body = sentTexts().join("\n");
     expect(body.match(/Error: boom/g)).toHaveLength(1);
+  });
+
+  it("names the host the alert came from", async () => {
+    await logError("Telegram", "Something failed");
+
+    expect(sentTexts()[0]).toContain("[Telegram (test) @ c0ffee1nstance]");
   });
 
   it("keeps the header when the runtime produced no stack", async () => {

--- a/tests/58.telegramLaunch.test.ts
+++ b/tests/58.telegramLaunch.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import {
+  isTelegramConflict,
+  launchWithConflictRetry,
+  pollingProbe
+} from "../utils/telegramLaunch.ts";
+
+const conflictError = (): Error =>
+  Object.assign(
+    new Error(
+      "409: Conflict: terminated by other getUpdates request; make sure that only one bot instance is running"
+    ),
+    { code: 409 }
+  );
+
+const apiError = (code: number, description: string): Error =>
+  Object.assign(new Error(`${String(code)}: ${description}`), { code });
+
+describe("isTelegramConflict", () => {
+  it("recognises the 409 raised when another instance polls the same token", () => {
+    expect(isTelegramConflict(conflictError())).toBe(true);
+  });
+
+  it("ignores other Telegram API errors", () => {
+    expect(isTelegramConflict(apiError(401, "Unauthorized"))).toBe(false);
+  });
+
+  it("ignores values that carry no status code", () => {
+    expect(isTelegramConflict(new Error("socket hang up"))).toBe(false);
+    expect(isTelegramConflict("409")).toBe(false);
+  });
+});
+
+describe("launchWithConflictRetry", () => {
+  it("retries until the competing instance releases the token", async () => {
+    const sleeps: number[] = [];
+    let attempts = 0;
+
+    await launchWithConflictRetry({
+      launch: () => {
+        attempts += 1;
+        return attempts < 3
+          ? Promise.reject(conflictError())
+          : Promise.resolve();
+      },
+      delaysMs: [10, 20, 30],
+      sleep: (ms) => {
+        sleeps.push(ms);
+        return Promise.resolve();
+      }
+    });
+
+    expect(attempts).toBe(3);
+    expect(sleeps).toEqual([10, 20]);
+  });
+
+  it("rethrows the conflict once every delay is spent", async () => {
+    let attempts = 0;
+
+    await expect(
+      launchWithConflictRetry({
+        launch: () => {
+          attempts += 1;
+          return Promise.reject(conflictError());
+        },
+        delaysMs: [10, 20],
+        sleep: () => Promise.resolve()
+      })
+    ).rejects.toThrow("409: Conflict");
+
+    expect(attempts).toBe(3);
+  });
+
+  it("does not retry an error that is not a conflict", async () => {
+    let attempts = 0;
+
+    await expect(
+      launchWithConflictRetry({
+        launch: () => {
+          attempts += 1;
+          return Promise.reject(apiError(401, "Unauthorized"));
+        },
+        delaysMs: [10, 20],
+        sleep: () => Promise.resolve()
+      })
+    ).rejects.toThrow("401: Unauthorized");
+
+    expect(attempts).toBe(1);
+  });
+
+  it("reports each conflict with the attempt number and the coming delay", async () => {
+    const reported: { attempt: number; delayMs: number }[] = [];
+    let attempts = 0;
+
+    await launchWithConflictRetry({
+      launch: () => {
+        attempts += 1;
+        return attempts < 2
+          ? Promise.reject(conflictError())
+          : Promise.resolve();
+      },
+      delaysMs: [10, 20],
+      sleep: () => Promise.resolve(),
+      onConflict: (attempt, delayMs) => {
+        reported.push({ attempt, delayMs });
+      }
+    });
+
+    expect(reported).toEqual([{ attempt: 1, delayMs: 10 }]);
+  });
+});
+
+describe("pollingProbe", () => {
+  it("passes while long polling runs", () => {
+    expect(pollingProbe(() => true)()).toEqual({ ok: true });
+  });
+
+  it("fails with a detail once polling stopped", () => {
+    expect(pollingProbe(() => false)()).toEqual({
+      ok: false,
+      detail: "Telegram long polling stopped"
+    });
+  });
+});

--- a/utils/debugLogger.ts
+++ b/utils/debugLogger.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import os from "node:os";
 import { MessageApp } from "../types.ts";
 import umami from "./umami.ts";
 import { splitText } from "./text.utils.ts";
@@ -222,8 +223,12 @@ const buildLogMessage = (
   const levelEmoji = level === "error" ? "❌" : "⚠️";
   const errorText = formatError(error);
   const processEnv = (process.env.NODE_ENV ?? "").trim();
+  // Every deployment sharing DEBUG_CHAT_ID reports into the same chat, and in
+  // Docker the hostname is the container id: it tells apart two instances of
+  // one bot, which is exactly what a "only one bot instance" conflict is about.
+  const host = os.hostname();
   return [
-    `${levelEmoji} [${messageApp} (${processEnv.length > 0 ? processEnv : "production"})] ${sanitizeSecrets(message)}`,
+    `${levelEmoji} [${messageApp} (${processEnv.length > 0 ? processEnv : "production"}) @ ${host}] ${sanitizeSecrets(message)}`,
     errorText != null ? `Details:\n${sanitizeSecrets(errorText)}` : null
   ]
     .filter((part): part is string => part != null)

--- a/utils/telegramLaunch.ts
+++ b/utils/telegramLaunch.ts
@@ -1,0 +1,74 @@
+import type { HealthProbe } from "./healthServer.ts";
+
+/** HTTP status Telegram answers with when two clients long-poll one token. */
+const CONFLICT_STATUS = 409;
+
+/**
+ * Waits between launch attempts, ~60s in total. A container replacement holds
+ * the token only while the outgoing instance drains its 50s long poll.
+ */
+export const DEFAULT_CONFLICT_DELAYS_MS = [5_000, 10_000, 15_000, 30_000];
+
+const sleepFor = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * True for the error telegraf surfaces when another process is polling the
+ * same bot token: "409: Conflict: terminated by other getUpdates request".
+ */
+export const isTelegramConflict = (error: unknown): boolean =>
+  error instanceof Error &&
+  (error as { code?: unknown }).code === CONFLICT_STATUS;
+
+export interface LaunchWithConflictRetryOptions {
+  /** Starts long polling; settles when polling ends or fails. */
+  launch: () => Promise<void>;
+  delaysMs?: number[];
+  sleep?: (ms: number) => Promise<void>;
+  onConflict?: (attempt: number, delayMs: number, error: unknown) => void;
+}
+
+/**
+ * Launches the bot, retrying while another instance still holds the token.
+ *
+ * Telegram serves `getUpdates` to a single client, so a rolling redeploy that
+ * overlaps the outgoing container makes the incoming one fail with 409. The
+ * conflict clears itself once the old instance exits, so retry rather than
+ * die; any other failure, and a conflict outliving every delay, is raised to
+ * the caller.
+ *
+ * Resolves when polling ends on purpose (shutdown stops the bot).
+ */
+export const launchWithConflictRetry = async ({
+  launch,
+  delaysMs = DEFAULT_CONFLICT_DELAYS_MS,
+  sleep = sleepFor,
+  onConflict
+}: LaunchWithConflictRetryOptions): Promise<void> => {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await launch();
+      return;
+    } catch (error) {
+      if (!isTelegramConflict(error) || attempt > delaysMs.length) throw error;
+      const delayMs = delaysMs[attempt - 1];
+      onConflict?.(attempt, delayMs, error);
+      await sleep(delayMs);
+    }
+  }
+};
+
+/**
+ * Health probe backed by the bot's polling state.
+ *
+ * Reaching the Bot API says nothing about long polling: a process whose
+ * `launch()` failed still answers `getMe` while receiving no update at all.
+ * Reporting that process unhealthy lets the container be replaced instead of
+ * lingering deaf.
+ */
+export const pollingProbe =
+  (isPolling: () => boolean): HealthProbe =>
+  () =>
+    isPolling()
+      ? { ok: true }
+      : { ok: false, detail: "Telegram long polling stopped" };


### PR DESCRIPTION
## Problem

Every redeploy posted this to the debug chat:

```
❌ [Telegram (production)] Failed to start app
Details:
Error: 409: Conflict: terminated by other getUpdates request; make sure that only one bot instance is running
```

Telegram serves `getUpdates` to a single client per token. A rolling redeploy runs the outgoing and incoming containers at the same time, so one of them loses the token and `bot.launch()` rejects with 409.

The alert was the visible half. The real problem: the losing process kept running. `apps/telegramApp.ts` logged the launch failure and fell through, mongoose kept the event loop alive, and the health probes (`mongo`, `telegramApi`) both still passed, since `getMe` succeeds whether or not the bot is polling. Coolify therefore saw a healthy container hosting a bot that receives nothing, with no further alert.

## Changes

- `utils/telegramLaunch.ts`: `launchWithConflictRetry` retries a 409 with 5s / 10s / 15s / 30s backoff, which covers the overlap window (the outgoing instance drains a 50s long poll). Any other error, and a conflict that outlives every delay, is raised.
- `pollingProbe` reports the bot unhealthy whenever long polling is not running, so a deaf process gets replaced instead of passing the healthcheck.
- A launch failure that survives the retries now closes the health server, disconnects mongo and exits 1, so `concurrently --kill-others-on-fail` tears the container down and the restart policy recovers it.
- Shutdown only calls `bot.stop()` once polling started: telegraf throws "Bot is not running!" otherwise, which turned a fast redeploy into a second spurious alert.
- Debug alerts now carry the host (`[Telegram (production) @ <container id>]`). Every deployment sharing `DEBUG_CHAT_ID` reports into the same chat, so an "only one bot instance" conflict was impossible to attribute.

## Tests

`tests/58.telegramLaunch.test.ts` covers conflict detection, retry until the token frees up, giving up after the last delay, no retry on non-conflict errors, the conflict callback, and both probe states. `tests/49.debugLogger.test.ts` covers the host tag.

`npm run lint`, `npm run build` and `npm test` (891 tests) pass locally.

## Note

This closes the race on the bot side. Configuring Coolify to stop the old container before starting the new one removes it at the source.
