### PR TITLE
fix(alerts): recover from Legifrance auth faults and quiet sync noise

### DIFF
--- a/notifications/notificationScheduler.ts
+++ b/notifications/notificationScheduler.ts
@@ -21,7 +21,7 @@ const RESCHEDULE_RETRY_DELAY_MS = 60 * 60 * 1000;
 
 // A run that never settles would take the whole schedule with it, because the
 // next occurrence is only armed once the current one finishes. Well above any
-// legitimate run (the slow-run warning trips at 5 minutes) and well under the
+// legitimate run (the slow-run warning trips at 15 minutes) and well under the
 // daily cadence, so it only fires on a genuine hang.
 const RUN_WATCHDOG_MS = 6 * 60 * 60 * 1000;
 

--- a/notifications/runNotificationProcess.ts
+++ b/notifications/runNotificationProcess.ts
@@ -14,7 +14,11 @@ import mongoose, { Types } from "mongoose";
 
 import { ExternalMessageOptions } from "../entities/Session.ts";
 import { refreshTelegramBlockedUsers } from "../entities/TelegramSession.ts";
-import { logError, logErrorForApps } from "../utils/debugLogger.ts";
+import {
+  logError,
+  logErrorForApps,
+  logWarningForApps
+} from "../utils/debugLogger.ts";
 import {
   getJORFMetaRecordsFromDate,
   getJORFRecordsFromDate,
@@ -95,8 +99,10 @@ async function fetchRange<T>(
 }
 
 // Ops latency warning only: the WhatsApp send guard re-checks the 24h window
-// in real time at each send, so a slow run no longer risks 131047 errors.
-const NOTIFICATION_DURATION_BEFORE_WARNING_MS = 5 * 60 * 1000; // 5 minutes
+// in real time at each send, so a slow run does not risk 131047 errors. Runs are
+// daily, so the threshold only has to sit above a legitimately slow backfill and
+// under the scheduler's watchdog.
+const NOTIFICATION_DURATION_BEFORE_WARNING_MS = 15 * 60 * 1000; // 15 minutes
 
 /**
  * How a scheduled cycle ended.
@@ -327,7 +333,7 @@ export async function runNotificationProcess(
     );
 
     if (delay > NOTIFICATION_DURATION_BEFORE_WARNING_MS) {
-      await logErrorForApps(
+      await logWarningForApps(
         targetApps,
         `Notification process took too long: ${formatDuration(delay)}.`
       );

--- a/tests/20.runNotificationProcess.test.ts
+++ b/tests/20.runNotificationProcess.test.ts
@@ -11,6 +11,7 @@ function emptyRange() {
 const h = vi.hoisted(() => ({
   logErrorSpy: vi.fn(() => Promise.resolve()),
   logErrorForAppsSpy: vi.fn(() => Promise.resolve()),
+  logWarningForAppsSpy: vi.fn(() => Promise.resolve()),
   umamiVerifiedSpy: vi.fn(() => Promise.resolve(true)),
   getRecords: vi.fn(() => Promise.resolve(emptyRange())),
   getMeta: vi.fn(() => Promise.resolve(emptyRange())),
@@ -46,7 +47,8 @@ vi.mock("../utils/umami.ts", () => ({
 }));
 vi.mock("../utils/debugLogger.ts", () => ({
   logError: h.logErrorSpy,
-  logErrorForApps: h.logErrorForAppsSpy
+  logErrorForApps: h.logErrorForAppsSpy,
+  logWarningForApps: h.logWarningForAppsSpy
 }));
 vi.mock("../utils/JORFSearch.utils.ts", () => ({
   getJORFRecordsFromDate: h.getRecords,
@@ -214,8 +216,27 @@ describe("runNotificationProcess — full run", () => {
 
   it("warns when the run exceeds the duration threshold", async () => {
     vi.useFakeTimers();
-    // Advance the clock past the 5-minute warning threshold mid-run so the
-    // end-of-run duration check trips the "took too long" warning.
+    // Advance the clock past the warning threshold mid-run so the end-of-run
+    // duration check trips the "took too long" warning.
+    h.getRecords.mockImplementationOnce(() => {
+      vi.advanceTimersByTime(16 * 60 * 1000);
+      return Promise.resolve(emptyRange());
+    });
+    try {
+      await runNotificationProcess(["Telegram"], { telegramBotToken: "TOK" });
+    } finally {
+      vi.useRealTimers();
+    }
+    // A slow run costs no notification, so it is a warning and not an error.
+    expect(h.logWarningForAppsSpy).toHaveBeenCalledWith(
+      ["Telegram"],
+      expect.stringContaining("took too long")
+    );
+    expect(h.logErrorForAppsSpy).not.toHaveBeenCalled();
+  });
+
+  it("stays quiet on a run that is merely slow", async () => {
+    vi.useFakeTimers();
     h.getRecords.mockImplementationOnce(() => {
       vi.advanceTimersByTime(6 * 60 * 1000);
       return Promise.resolve(emptyRange());
@@ -225,10 +246,7 @@ describe("runNotificationProcess — full run", () => {
     } finally {
       vi.useRealTimers();
     }
-    expect(h.logErrorForAppsSpy).toHaveBeenCalledWith(
-      ["Telegram"],
-      expect.stringContaining("took too long")
-    );
+    expect(h.logWarningForAppsSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/49.debugLogger.test.ts
+++ b/tests/49.debugLogger.test.ts
@@ -20,7 +20,8 @@ vi.mock("node:os", () => ({ default: { hostname: () => "c0ffee1nstance" } }));
 process.env.DEBUG_CHAT_ID = "debug-chat-id";
 process.env.TELEGRAM_DEBUG_BOT_TOKEN = "debug-bot-token";
 
-const { logError, logErrorForApps } = await import("../utils/debugLogger.ts");
+const { logError, logErrorForApps, logWarningForApps } =
+  await import("../utils/debugLogger.ts");
 
 const sentTexts = () =>
   postSpy.mock.calls.map(
@@ -70,6 +71,25 @@ describe("logErrorForApps", () => {
 
   it("sends nothing when no app is affected", async () => {
     await logErrorForApps([], "nobody cares");
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("logWarningForApps", () => {
+  it("sends one warning naming every affected app", async () => {
+    await logWarningForApps(
+      ["Telegram", "WhatsApp"],
+      "Notification process took too long"
+    );
+
+    expect(postSpy).toHaveBeenCalledTimes(1);
+    expect(sentTexts()[0]).toContain("⚠️ [Telegram, WhatsApp");
+    // A warning is not an error: it must not move the per-app error counters.
+    expect(umamiLogSpy).not.toHaveBeenCalled();
+  });
+
+  it("sends nothing when no app is affected", async () => {
+    await logWarningForApps([], "nobody cares");
     expect(postSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/52.legifranceMeta.test.ts
+++ b/tests/52.legifranceMeta.test.ts
@@ -67,6 +67,37 @@ function mockPost(onSummary: () => unknown, expiresIn = 3600) {
   });
 }
 
+/** Calls to the OAuth token endpoint, as opposed to the summary endpoint. */
+function tokenCalls() {
+  return postSpy.mock.calls.filter((c) => String(c[0]).includes("oauth"));
+}
+
+function summaryCalls() {
+  return postSpy.mock.calls.filter((c) => !String(c[0]).includes("oauth"));
+}
+
+/** A rejection shaped like the one axios raises, so `isAxiosError` accepts it. */
+function axiosError(status: number, data?: unknown) {
+  return Object.assign(
+    new Error(`Request failed with status code ${String(status)}`),
+    { isAxiosError: true, response: { status, data } }
+  );
+}
+
+const ONE_TEXT_SUMMARY = {
+  data: {
+    items: [
+      {
+        joCont: {
+          structure: {
+            liens: [{ id: "JORFTEXT000000000001", titre: "Texte" }]
+          }
+        }
+      }
+    ]
+  }
+};
+
 function mockDatesWithoutJo(epochs: number[] = []) {
   getSpy.mockImplementation((url: string) => {
     if (url.includes("datesWithoutJo")) {
@@ -251,6 +282,111 @@ describe("Legifrance access token", () => {
       String(c[0]).includes("oauth")
     );
     expect(tokenCalls).toHaveLength(1);
+  });
+
+  it("mints a single token for callers that start at the same time", async () => {
+    mockDatesWithoutJo();
+    let releaseToken = () => {
+      /* replaced below */
+    };
+    const gate = new Promise<void>((resolve) => {
+      releaseToken = resolve;
+    });
+    postSpy.mockImplementation((url: string) => {
+      if (url.includes("oauth")) return gate.then(() => tokenResponse());
+      return Promise.resolve({ data: { items: [] } });
+    });
+
+    const days = Promise.all([
+      fetchLegifranceMetaDay(DAY, ["Telegram"]),
+      fetchLegifranceMetaDay(new Date(2026, 7, 18), ["Telegram"])
+    ]);
+    releaseToken();
+    await days;
+
+    // PISTE throttles a client that opens several token requests at once.
+    expect(tokenCalls()).toHaveLength(1);
+  });
+
+  it("mints a fresh token and replays a call answered with a 401", async () => {
+    mockDatesWithoutJo();
+    let summaries = 0;
+    postSpy.mockImplementation((url: string) => {
+      if (url.includes("oauth")) return Promise.resolve(tokenResponse());
+      summaries += 1;
+      return summaries === 1
+        ? Promise.reject(axiosError(401))
+        : Promise.resolve(ONE_TEXT_SUMMARY);
+    });
+
+    const result = await fetchLegifranceMetaDay(DAY, ["Telegram"]);
+
+    expect(result?.items.map((i) => i.id)).toEqual(["JORFTEXT000000000001"]);
+    expect(tokenCalls()).toHaveLength(2);
+    expect(logErrorForAppsSpy).not.toHaveBeenCalled();
+  });
+
+  it("gives up when a freshly minted token is refused too", async () => {
+    mockDatesWithoutJo();
+    postSpy.mockImplementation((url: string) =>
+      url.includes("oauth")
+        ? Promise.resolve(tokenResponse())
+        : Promise.reject(axiosError(401))
+    );
+
+    const result = await fetchLegifranceMetaDay(DAY, ["Telegram"]);
+
+    expect(result).toBeNull();
+    // One replay, not a loop.
+    expect(summaryCalls()).toHaveLength(2);
+    expect(logErrorForAppsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails fast and names the reason when the credentials are rejected", async () => {
+    mockDatesWithoutJo();
+    postSpy.mockImplementation((url: string) =>
+      url.includes("oauth")
+        ? Promise.reject(
+            axiosError(400, {
+              error: "invalid_client",
+              error_description: "Invalid client"
+            })
+          )
+        : Promise.resolve({ data: { items: [] } })
+    );
+
+    const result = await fetchLegifranceMetaDay(DAY, ["Telegram"]);
+
+    expect(result).toBeNull();
+    expect(tokenCalls()).toHaveLength(1);
+    expect(logErrorForAppsSpy).toHaveBeenCalledWith(
+      ["Telegram"],
+      expect.stringContaining("Error fetching the Legifrance JO summary"),
+      expect.objectContaining({
+        message: expect.stringContaining("invalid_client") as string
+      })
+    );
+  });
+
+  it("retries a token rejection that carries no OAuth error code", async () => {
+    mockDatesWithoutJo();
+    postSpy.mockImplementation((url: string) =>
+      url.includes("oauth")
+        ? Promise.reject(axiosError(400))
+        : Promise.resolve({ data: { items: [] } })
+    );
+
+    const result = await withFakeTimers(() =>
+      fetchLegifranceMetaDay(DAY, ["Telegram"])
+    );
+
+    expect(result).toBeNull();
+    expect(tokenCalls()).toHaveLength(6); // RETRY_MAX + 1
+    expect(logErrorForAppsSpy).toHaveBeenCalledWith(
+      ["Telegram"],
+      expect.stringContaining("aborted after"),
+      expect.anything()
+    );
   });
 
   it("renews a token that is about to expire", async () => {

--- a/tests/54.matrixSyncHealth.test.ts
+++ b/tests/54.matrixSyncHealth.test.ts
@@ -36,19 +36,39 @@ let clock: number;
 
 const healthWithClock = () => createSyncHealth("Tchap", { now: () => clock });
 
+/** Drives an outage past both alert gates: enough attempts, over long enough. */
+const failIntoAlert = async (record: () => Promise<unknown>) => {
+  for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
+    if (i > 0) clock += SYNC_ALERT_AFTER_MS;
+    await record();
+  }
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   clock = 0;
 });
 
 describe("sync health alerting", () => {
-  it("stays quiet while failures are below the threshold", async () => {
+  it("stays quiet while the attempts are too few, however long they span", async () => {
     const health = healthWithClock();
 
     for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES - 1; i++) {
-      clock += 1000;
+      await health.recordFailure(tokenError());
+      clock += SYNC_ALERT_AFTER_MS;
+    }
+
+    expect(logErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("stays quiet through a burst of failures that ends inside the window", async () => {
+    const health = healthWithClock();
+
+    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES + 5; i++) {
+      clock += 20_000;
       await health.recordFailure(tokenError());
     }
+    await health.recordSuccess();
 
     expect(logErrorSpy).not.toHaveBeenCalled();
   });
@@ -57,7 +77,7 @@ describe("sync health alerting", () => {
     const health = healthWithClock();
 
     for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES + 5; i++) {
-      clock += 1000;
+      clock += 60_000;
       await health.recordFailure(tokenError());
     }
 
@@ -68,7 +88,7 @@ describe("sync health alerting", () => {
     expect(alert).not.toContain("[object Object]");
   });
 
-  it("alerts on a short but long-lasting outage", async () => {
+  it("alerts on an outage that spans the window in few attempts", async () => {
     const health = healthWithClock();
 
     await health.recordFailure(tokenError());
@@ -81,10 +101,7 @@ describe("sync health alerting", () => {
   it("re-alerts only once the cooldown has elapsed", async () => {
     const health = healthWithClock();
 
-    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
-      clock += 1000;
-      await health.recordFailure(tokenError());
-    }
+    await failIntoAlert(() => health.recordFailure(tokenError()));
     expect(logErrorSpy).toHaveBeenCalledTimes(1);
 
     clock += SYNC_REALERT_COOLDOWN_MS - 1;
@@ -99,10 +116,7 @@ describe("sync health alerting", () => {
   it("reports recovery once syncs have held for the confirmation window", async () => {
     const health = healthWithClock();
 
-    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
-      clock += 60_000;
-      await health.recordFailure(tokenError());
-    }
+    await failIntoAlert(() => health.recordFailure(tokenError()));
     await health.recordSuccess();
     expect(logWarningSpy).not.toHaveBeenCalled();
 
@@ -117,14 +131,16 @@ describe("sync health alerting", () => {
     const health = healthWithClock();
 
     await health.recordFailure(tokenError());
-    clock += 4 * 60_000;
+    clock += 6 * 60_000;
     await health.recordFailure(tokenError());
     await health.recordSuccess();
 
     clock += SYNC_RECOVERY_CONFIRM_MS * 3;
     await health.recordSuccess();
 
-    expect(recoveryTexts()[0]).toContain("recovered after 4m0s");
+    expect(recoveryTexts()[0]).toContain("recovered after 6m0s");
+    // The failure alert only ever reported the attempts made by then.
+    expect(recoveryTexts()[0]).toContain("2 failed attempts");
   });
 
   it("stays on one incident while sync flaps", async () => {
@@ -133,10 +149,7 @@ describe("sync health alerting", () => {
     // Two flap cycles, kept inside SYNC_REALERT_COOLDOWN_MS so the only thing
     // that could speak up is the flapping itself.
     for (let round = 0; round < 2; round++) {
-      for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
-        clock += 30_000;
-        await health.recordFailure(tokenError());
-      }
+      await failIntoAlert(() => health.recordFailure(tokenError()));
       await health.recordSuccess();
       clock += SYNC_RECOVERY_CONFIRM_MS - 60_000;
       await health.recordSuccess();
@@ -149,10 +162,7 @@ describe("sync health alerting", () => {
   it("keeps the re-alert cooldown across a brief success", async () => {
     const health = healthWithClock();
 
-    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
-      clock += 1000;
-      await health.recordFailure(tokenError());
-    }
+    await failIntoAlert(() => health.recordFailure(tokenError()));
     expect(logErrorSpy).toHaveBeenCalledTimes(1);
     const alertedAt = clock;
 
@@ -179,32 +189,24 @@ describe("sync health alerting", () => {
   it("starts a fresh streak after a confirmed recovery", async () => {
     const health = healthWithClock();
 
-    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
-      clock += 1000;
-      await health.recordFailure(tokenError());
-    }
+    await failIntoAlert(() => health.recordFailure(tokenError()));
     await health.recordSuccess();
     clock += SYNC_RECOVERY_CONFIRM_MS;
     await health.recordSuccess();
-
-    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES - 1; i++) {
-      clock += 1000;
-      await health.recordFailure(tokenError());
-    }
     expect(logErrorSpy).toHaveBeenCalledTimes(1);
 
-    clock += 1000;
-    await health.recordFailure(tokenError());
+    // The confirmed recovery closed the incident, so the re-alert cooldown no
+    // longer applies: the next outage is judged on its own gates.
+    await failIntoAlert(() => health.recordFailure(tokenError()));
     expect(logErrorSpy).toHaveBeenCalledTimes(2);
   });
 
   it("keeps a node network error readable", async () => {
     const health = healthWithClock();
 
-    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
-      clock += 1000;
-      await health.recordFailure(new Error("read ECONNRESET"));
-    }
+    await failIntoAlert(() =>
+      health.recordFailure(new Error("read ECONNRESET"))
+    );
 
     expect(alertTexts()[0]).toContain("read ECONNRESET");
   });
@@ -234,10 +236,9 @@ describe("attachSyncHealth", () => {
     const client = fakeClient(() => Promise.reject(new Error("boom")));
     attachSyncHealth(client, healthWithClock());
 
-    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
-      clock += 1000;
-      await expect(client.doSync("s41")).rejects.toThrow("boom");
-    }
+    await failIntoAlert(() =>
+      expect(client.doSync("s41")).rejects.toThrow("boom")
+    );
 
     expect(logErrorSpy).toHaveBeenCalledTimes(1);
     expect(alertTexts()[0]).toContain("boom");
@@ -250,10 +251,9 @@ describe("attachSyncHealth", () => {
     );
     attachSyncHealth(client, healthWithClock());
 
-    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
-      clock += 1000;
-      await expect(client.doSync("s41")).rejects.toThrow("boom");
-    }
+    await failIntoAlert(() =>
+      expect(client.doSync("s41")).rejects.toThrow("boom")
+    );
     fail = false;
     await client.doSync("s41");
     clock += SYNC_RECOVERY_CONFIRM_MS;
@@ -282,10 +282,7 @@ describe("sync health readiness", () => {
   it("turns unhealthy once the outage is reported", async () => {
     const health = healthWithClock();
 
-    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
-      clock += 1000;
-      await health.recordFailure(tokenError());
-    }
+    await failIntoAlert(() => health.recordFailure(tokenError()));
 
     expect(health.isHealthy()).toBe(false);
   });
@@ -293,10 +290,7 @@ describe("sync health readiness", () => {
   it("stays unhealthy until the recovery is confirmed", async () => {
     const health = healthWithClock();
 
-    for (let i = 0; i < SYNC_ALERT_AFTER_FAILURES; i++) {
-      clock += 1000;
-      await health.recordFailure(tokenError());
-    }
+    await failIntoAlert(() => health.recordFailure(tokenError()));
     await health.recordSuccess();
     expect(health.isHealthy()).toBe(false);
 

--- a/utils/debugLogger.ts
+++ b/utils/debugLogger.ts
@@ -259,6 +259,27 @@ export const logError = async (
 };
 
 /**
+ * The {@link logWarning} counterpart of {@link logErrorForApps}: one Telegram
+ * alert naming every affected app, for a condition that is worth watching but
+ * did not cost anyone a notification.
+ */
+export const logWarningForApps = async (
+  messageApps: MessageApp[],
+  message: string,
+  error?: unknown
+): Promise<void> => {
+  if (messageApps.length === 0) return;
+  if (messageApps.length === 1) {
+    await logWarning(messageApps[0], message, error);
+    return;
+  }
+  logToConsole("warning", message, error);
+  await sendTelegramDebugMessage(
+    buildLogMessage("warning", messageApps.join(", "), message, error)
+  );
+};
+
+/**
  * Reports a single failure that affects several apps at once (a shared
  * dependency being down, for instance). Emits one Telegram alert naming every
  * affected app instead of one alert per app: `sendTelegramDebugMessage` sleeps

--- a/utils/httpRetry.utils.ts
+++ b/utils/httpRetry.utils.ts
@@ -10,12 +10,25 @@ export const BASE_RETRY_DELAY_MS = 1000;
 export const REQUEST_TIMEOUT_MS = 10_000;
 
 /**
+ * A fault the upstream is expected to recover from on its own, whatever status
+ * line carried it. Statuses alone cannot express this: a 4xx normally means
+ * "do not try again", yet some upstreams answer a throttled or half-broken
+ * request with one. Raising this instead makes {@link shouldRetry} retry.
+ */
+export class TransientUpstreamError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "TransientUpstreamError";
+  }
+}
+
+/**
  * A 2xx response whose body is not the expected JSON payload: an HTML login
  * page, an overload notice, or a bare `null`. The status line carries no signal
  * in that case, so the body is the only tell, and the condition is usually
  * transient on the server side.
  */
-export class NonJsonResponseError extends Error {
+export class NonJsonResponseError extends TransientUpstreamError {
   constructor(source: string) {
     super(`${source} answered 2xx with a non-JSON body`);
     this.name = "NonJsonResponseError";
@@ -37,7 +50,7 @@ export function assertJsonPayload<T>(
 }
 
 export function shouldRetry(e: unknown): boolean {
-  if (e instanceof NonJsonResponseError) return true;
+  if (e instanceof TransientUpstreamError) return true;
   if (!isAxiosError(e)) return false;
   const s = e.response?.status;
   return !(s && s >= 400 && s < 500 && s !== 408 && s !== 429);

--- a/utils/legifrance.utils.ts
+++ b/utils/legifrance.utils.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosResponse, isAxiosError } from "axios";
 import { MessageApp } from "../types.ts";
 import { dateToString } from "./date.utils.ts";
 import {
@@ -11,6 +11,7 @@ import {
   REQUEST_TIMEOUT_MS,
   RETRY_MAX,
   shouldRetry,
+  TransientUpstreamError,
   waitBeforeRetry
 } from "./httpRetry.utils.ts";
 import umami from "./umami.ts";
@@ -55,11 +56,13 @@ interface CachedToken {
 }
 
 let cachedToken: CachedToken | null = null;
+let inFlightToken: Promise<string> | null = null;
 let datesWithoutJoCache: { days: Set<string>; fetchedAt: number } | null = null;
 
 /** Test seam: drops the token and the no-JO day list. */
 export function resetLegifranceCaches(): void {
   cachedToken = null;
+  inFlightToken = null;
   datesWithoutJoCache = null;
 }
 
@@ -68,15 +71,57 @@ interface TokenResponse {
   expires_in?: number;
 }
 
-async function getAccessToken(): Promise<string> {
-  const now = Date.now();
-  if (
-    cachedToken != null &&
-    now < cachedToken.expiresAt - TOKEN_EXPIRY_MARGIN_MS
-  ) {
-    return cachedToken.value;
-  }
+interface OAuthErrorBody {
+  error?: string;
+  error_description?: string;
+}
 
+/**
+ * OAuth codes that describe the client rather than the moment: the same request
+ * fails identically until someone changes the credentials or the PISTE app
+ * subscription, so retrying only delays the alert. Anything else, a bare 400
+ * included, is read as throttling and retried.
+ */
+const FATAL_OAUTH_ERRORS = new Set([
+  "invalid_client",
+  "invalid_grant",
+  "unauthorized_client",
+  "invalid_scope"
+]);
+
+function readOAuthError(error: unknown): OAuthErrorBody | null {
+  if (!isAxiosError(error)) return null;
+  const data: unknown = error.response?.data;
+  if (data == null || typeof data !== "object") return null;
+  return data;
+}
+
+/**
+ * Turns a token endpoint rejection into an error that says what PISTE answered.
+ * The status alone does not: a 400 is `invalid_client` for dead credentials and
+ * an unlabelled throttle otherwise, and only the body tells the two apart.
+ */
+function describeTokenFailure(error: unknown): Error {
+  const status = isAxiosError(error) ? error.response?.status : undefined;
+  const body = readOAuthError(error);
+  const context = [
+    status != null ? `HTTP ${String(status)}` : null,
+    body?.error,
+    body?.error_description
+  ]
+    .filter((part): part is string => part != null && part.length > 0)
+    .join(" ");
+  const message =
+    context.length > 0
+      ? `Legifrance token endpoint rejected the request (${context})`
+      : "Legifrance token endpoint rejected the request";
+
+  return body?.error != null && FATAL_OAUTH_ERRORS.has(body.error)
+    ? new Error(message, { cause: error })
+    : new TransientUpstreamError(message, { cause: error });
+}
+
+async function requestAccessToken(): Promise<string> {
   const clientId = process.env.LEGIFRANCE_CLIENT_ID;
   const clientSecret = process.env.LEGIFRANCE_CLIENT_SECRET;
   if (!clientId || !clientSecret) {
@@ -92,9 +137,15 @@ async function getAccessToken(): Promise<string> {
     scope: "openid"
   });
 
-  const res = await legifranceAxios.post<TokenResponse>(TOKEN_URL, body, {
-    headers: { "Content-Type": "application/x-www-form-urlencoded" }
-  });
+  const requestedAt = Date.now();
+  let res: AxiosResponse<TokenResponse>;
+  try {
+    res = await legifranceAxios.post<TokenResponse>(TOKEN_URL, body, {
+      headers: { "Content-Type": "application/x-www-form-urlencoded" }
+    });
+  } catch (error) {
+    throw describeTokenFailure(error);
+  }
   const data = assertJsonPayload(res.data, "Legifrance token endpoint");
 
   if (!data.access_token) {
@@ -104,31 +155,76 @@ async function getAccessToken(): Promise<string> {
   // expires_in is in seconds; fall back to a short life so a malformed
   // response cannot pin a stale token in memory.
   const lifetimeMs = (data.expires_in ?? 60) * 1000;
-  cachedToken = { value: data.access_token, expiresAt: now + lifetimeMs };
+  cachedToken = {
+    value: data.access_token,
+    expiresAt: requestedAt + lifetimeMs
+  };
   return cachedToken.value;
 }
 
+/**
+ * The bearer for every call, minted at most once at a time: PISTE throttles a
+ * client that opens several token requests at once, and concurrent callers all
+ * want the same token anyway.
+ */
+async function getAccessToken(): Promise<string> {
+  if (
+    cachedToken != null &&
+    Date.now() < cachedToken.expiresAt - TOKEN_EXPIRY_MARGIN_MS
+  ) {
+    return cachedToken.value;
+  }
+
+  inFlightToken ??= requestAccessToken().finally(() => {
+    inFlightToken = null;
+  });
+  return await inFlightToken;
+}
+
+function isUnauthorized(error: unknown): boolean {
+  if (!isAxiosError(error)) return false;
+  const status = error.response?.status;
+  return status === 401 || status === 403;
+}
+
+/**
+ * Sends an authenticated call, and on a rejected bearer mints a fresh one and
+ * sends it once more. A token can be refused before its announced expiry, and
+ * the cached value would otherwise keep every later call failing too. A second
+ * rejection is a real credential or permission problem and propagates.
+ */
+async function legifranceRequest<T>(
+  path: string,
+  send: (token: string) => Promise<AxiosResponse<T>>
+): Promise<T> {
+  let res: AxiosResponse<T>;
+  try {
+    res = await send(await getAccessToken());
+  } catch (error) {
+    if (!isUnauthorized(error)) throw error;
+    cachedToken = null;
+    res = await send(await getAccessToken());
+  }
+  return assertJsonPayload(res.data, `Legifrance ${path}`);
+}
+
 async function legifrancePost<T>(path: string, payload: unknown): Promise<T> {
-  const token = await getAccessToken();
-  const res = await legifranceAxios.post<T>(
-    `${getLegifranceApiUrl()}${path}`,
-    payload,
-    {
+  return await legifranceRequest<T>(path, (token) =>
+    legifranceAxios.post<T>(`${getLegifranceApiUrl()}${path}`, payload, {
       headers: {
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json"
       }
-    }
+    })
   );
-  return assertJsonPayload(res.data, `Legifrance ${path}`);
 }
 
 async function legifranceGet<T>(path: string): Promise<T> {
-  const token = await getAccessToken();
-  const res = await legifranceAxios.get<T>(`${getLegifranceApiUrl()}${path}`, {
-    headers: { Authorization: `Bearer ${token}` }
-  });
-  return assertJsonPayload(res.data, `Legifrance ${path}`);
+  return await legifranceRequest<T>(path, (token) =>
+    legifranceAxios.get<T>(`${getLegifranceApiUrl()}${path}`, {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+  );
 }
 
 interface DatesWithNoJoResponse {

--- a/utils/matrixSyncHealth.ts
+++ b/utils/matrixSyncHealth.ts
@@ -2,11 +2,16 @@ import { MessageApp } from "../types.ts";
 import { logError, logWarning } from "./debugLogger.ts";
 import { describeMatrixPayload } from "./matrixLogService.ts";
 
-/** Consecutive failed syncs that make an outage worth reporting. */
-export const SYNC_ALERT_AFTER_FAILURES = 5;
+/**
+ * An outage is reported once it has spanned this many consecutive failed syncs
+ * and lasted {@link SYNC_ALERT_AFTER_MS}. Both are required: a homeserver that
+ * answers again within a few minutes needs no one woken up, and a single failed
+ * attempt says nothing about how the next one will go.
+ */
+export const SYNC_ALERT_AFTER_FAILURES = 2;
 
-/** Or, for a slow sync loop, how long the failures may last before reporting. */
-export const SYNC_ALERT_AFTER_MS = 2 * 60 * 1000;
+/** How long the failures must last before the outage is reported. */
+export const SYNC_ALERT_AFTER_MS = 5 * 60 * 1000;
 
 /** Delay before a still-failing sync is reported again. */
 export const SYNC_REALERT_COOLDOWN_MS = 30 * 60 * 1000;
@@ -78,7 +83,7 @@ export const createSyncHealth = (
       recoveringSince = null;
 
       const worthReporting =
-        failureCount >= SYNC_ALERT_AFTER_FAILURES ||
+        failureCount >= SYNC_ALERT_AFTER_FAILURES &&
         at - firstFailureAt >= SYNC_ALERT_AFTER_MS;
       if (!worthReporting) return;
       if (lastAlertAt != null && at - lastAlertAt < SYNC_REALERT_COOLDOWN_MS)
@@ -87,7 +92,7 @@ export const createSyncHealth = (
       lastAlertAt = at;
       await logError(
         messageApp,
-        `Matrix sync failing for ${formatOutage(at - firstFailureAt)} (${String(failureCount)} attempts)`,
+        `Matrix sync failing for ${formatOutage(at - firstFailureAt)} (${String(failureCount)} attempts so far)`,
         describeMatrixPayload(error)
       );
     },
@@ -103,10 +108,14 @@ export const createSyncHealth = (
 
       // Syncs stopped failing at the first success, not at this confirmation.
       const outage = recoveringSince - (firstFailureAt ?? recoveringSince);
+      // The failure alert froze both figures at the moment it was sent, and the
+      // re-alert cooldown usually keeps it from being sent twice, so this is the
+      // only place the whole outage is reported.
+      const attempts = failureCount;
       reset();
       await logWarning(
         messageApp,
-        `Matrix sync recovered after ${formatOutage(outage)}`
+        `Matrix sync recovered after ${formatOutage(outage)} (${String(attempts)} failed attempts)`
       );
     }
   };


### PR DESCRIPTION
Four production alerts from the last week, all noise or lost data rather than crashes.

## Legifrance auth

`legifrancePost` was answered with a 401 on 2026-08-20 and the JO of that day was lost: a 401 is a 4xx, so `shouldRetry` refuses it, and the cached bearer was never dropped. On 2026-08-26 the token endpoint answered 400, which failed the same way and carried no OAuth body, so dead credentials were indistinguishable from PISTE throttling.

- The token is now minted single-flight: concurrent callers share one POST instead of racing, which is what PISTE throttles.
- A token rejection is classified from its OAuth body. `invalid_client`, `invalid_grant`, `unauthorized_client` and `invalid_scope` fail fast with the reason in the alert; anything else, a bare 400 included, is read as throttling and retried through the existing backoff.
- A 401 or 403 on an authenticated call drops the cached bearer, mints a fresh one and replays the call once. A second rejection propagates, because a fresh token being refused is a real permission problem.

`shouldRetry` gained a `TransientUpstreamError` marker for the "retry this whatever the status line says" case; `NonJsonResponseError` now extends it, so every existing call site is unchanged.

## Matrix sync alerts

`Matrix sync failing for 57s (5 attempts)` paged for an outage that was over 1m38s later. The gate was 5 failures **or** 2 minutes, so a handful of quick timeouts was enough.

- An outage must now span 5 minutes **and** at least 2 attempts.
- The failure line says "attempts so far", and the recovery line reports the total attempt count. The re-alert cooldown means the failure alert is usually never refreshed, so the recovery line is the only place the whole outage is described: `failing for 2m16s` followed by `recovered after 32m7s` was accurate but unreadable.

## Slow-run warning

`Notification process took too long: 5 minutes, 20 seconds` was sent as an error. Runs are daily and the scheduler watchdog sits at 6h, so a 5m20s run costs nothing.

- Threshold 5 min to 15 min, emitted as a warning through a new `logWarningForApps` instead of an error, so it no longer moves the per-app error counters.

## Tests

New coverage for the 401 replay, a refused fresh token, a fatal `invalid_client`, a retried unlabelled 400, and the single-flight token. The sync health suite now drives outages through both gates, and asserts the attempt count on the recovery line. Full suite green locally (900 tests), along with lint and build.
